### PR TITLE
Simplified Verification for Referenced Parameters / Variables. (Fix for 5308)

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
@@ -23,24 +23,16 @@ An expression could be: "[ concat ( variables ( 'test' ), ...)]"
 #>
 $exprStrOrQuote = [Regex]::new('(?<!\\)(?>"\s{0,}\[")', 'RightToLeft')
 foreach ($parameter in $TemplateObject.parameters.psobject.properties) {
-
-    if (!($parameter.name.startswith('__')) -and ($parameter.name -ne 'copy') ) {
-        $findVar = [Regex]::new("parameters\s{0,}\(\s{0,}'$($Parameter.Name)'\s{0,}\)")
-        $foundRefs = @($findVar.Matches($TemplateText))
-        if (-not $foundRefs) {
-            Write-Error -Message "Unreferenced parameter: $($Parameter.Name)" -ErrorId Parameters.Must.Be.Referenced -TargetObject $parameter
-        } else {
-            foreach ($fr in $foundRefs) {
-                $foundQuote =$exprStrOrQuote.Match($TemplateText, $fr.Index)                
-                if ($foundQuote.Value -eq '"') {
-                    Write-Error -Message "Unreferenced parameter: $($Parameter.Name)" -ErrorId Parameters.Must.Be.Referenced -TargetObject $parameter
-                }
+    $findVar = [Regex]::new("parameters\s{0,}\(\s{0,}'$($Parameter.Name)'\s{0,}\)")
+    $foundRefs = @($findVar.Matches($TemplateText))
+    if (-not $foundRefs) {
+        Write-Error -Message "Unreferenced parameter: $($Parameter.Name)" -ErrorId Parameters.Must.Be.Referenced -TargetObject $parameter
+    } else {
+        foreach ($fr in $foundRefs) {
+            $foundQuote =$exprStrOrQuote.Match($TemplateText, $fr.Index)                
+            if ($foundQuote.Value -eq '"') {
+                Write-Error -Message "Unreferenced parameter: $($Parameter.Name)" -ErrorId Parameters.Must.Be.Referenced -TargetObject $parameter
             }
         }
-
     }
 }
- 
-
-
-

--- a/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
@@ -21,14 +21,10 @@
 An expression could be: "[ concat ( variables ( 'test' ), ...)]"
 
 #>
-$exprStrOrQuote = [Regex]::new('(?<!\\)(?>"\s{0,}\[|")', 'RightToLeft')
+$exprStrOrQuote = [Regex]::new('(?<!\\)(?>"\s{0,}\[")', 'RightToLeft')
 foreach ($parameter in $TemplateObject.parameters.psobject.properties) {
 
-    if (!($parameter.name.startswith('__'))) {
-        
-        if ($TemplateText -notmatch ) {
-            Write-Error -Message "Unreferenced parameter: $($Parameter.Name)" -ErrorId Parameters.Must.Be.Referenced -TargetObject $parameter
-        }
+    if (!($parameter.name.startswith('__')) -and ($parameter.name -ne 'copy') ) {
         $findVar = [Regex]::new("parameters\s{0,}\(\s{0,}'$($Parameter.Name)'\s{0,}\)")
         $foundRefs = @($findVar.Matches($TemplateText))
         if (-not $foundRefs) {

--- a/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
@@ -27,7 +27,7 @@ foreach ($parameter in $TemplateObject.parameters.psobject.properties) {
 
     if (!($parameter.name.startswith('__'))) {
         
-        if ($TemplateText -notmatch "(?s)`"\s{0,}\[.*?parameters\s{0,}\(\s{0,}'$($Parameter.Name)'") {
+        if ($TemplateText -notmatch "parameters\s{0,}\(\s{0,}'$($Parameter.Name)'\s{0,}\)") {
             Write-Error -Message "Unreferenced parameter: $($Parameter.Name)" -ErrorId Parameters.Must.Be.Referenced -TargetObject $parameter
         }
 

--- a/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
@@ -9,15 +9,14 @@
 )
 
 <# REGEX
-- start with "
-- 0 or more whitespace
-- open bracket for expression [
-- any number of chars, the reference can be anywhere in the expression
-- parameters
-- 0 or more whitespace
-- open paren (
-- 0 or more whitespace
-- opening '
+- 
+- variables
+- whitespace
+- ('
+- whitespace
+- <VariableName>
+- whitespace
+- ')
 
 An expression could be: "[ concat ( variables ( 'test' ), ...)]"
 
@@ -25,18 +24,24 @@ An expression could be: "[ concat ( variables ( 'test' ), ...)]"
 
 # TODO: Need to properly check for variable copy, see: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-multiple#variable-iteration
 
+$exprStrOrQuote = [Regex]::new('(?<!\\)(?>"\s{0,}\[|")', 'RightToLeft')
+
 foreach ($variable in $TemplateObject.variables.psobject.properties) {
-
+    
     # TODO: if the variable name is "copy": we need to loop through the array and pull each var and check individually
+    
     if (!($variable.name.startswith('__')) -and ($variable.name -ne 'copy') ) {
-
-        if ($TemplateText -notmatch "variables\s{0,}\(\s{0,}'$($Variable.Name)'\s{0,}\)") {
+        $findVar = [Regex]::new("variables\s{0,}\(\s{0,}'$($Variable.Name)'\s{0,}\)")
+        $foundRefs = @($findVar.Matches($TemplateText))
+        if (-not $foundRefs) {
             Write-Error -Message "Unreferenced variable: $($Variable.Name)" -ErrorId Variables.Must.Be.Referenced -TargetObject $variable
-        }
-        
+        } else {
+            foreach ($fr in $foundRefs) {
+                $foundQuote =$exprStrOrQuote.Match($TemplateText, $fr.Index)                
+                if ($foundQuote.Value -eq '"') {
+                    Write-Error -Message "Unreferenced variable: $($Variable.Name)" -ErrorId Variables.Must.Be.Referenced -TargetObject $variable
+                }
+            }
+        }        
     }
 }
- 
-
-
-

--- a/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
@@ -30,7 +30,7 @@ foreach ($variable in $TemplateObject.variables.psobject.properties) {
     
     # TODO: if the variable name is "copy": we need to loop through the array and pull each var and check individually
     
-    if (!($variable.name.startswith('__')) -and ($variable.name -ne 'copy') ) {
+    if ($variable.name -ne 'copy' ) {
         $findVar = [Regex]::new("variables\s{0,}\(\s{0,}'$($Variable.Name)'\s{0,}\)")
         $foundRefs = @($findVar.Matches($TemplateText))
         if (-not $foundRefs) {

--- a/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
@@ -30,7 +30,7 @@ foreach ($variable in $TemplateObject.variables.psobject.properties) {
     # TODO: if the variable name is "copy": we need to loop through the array and pull each var and check individually
     if (!($variable.name.startswith('__')) -and ($variable.name -ne 'copy') ) {
 
-        if ($TemplateText -notmatch "(?s)`"\s{0,}\[.*?variables\s{0,}\(\s{0,}'$($Variable.Name)'") {
+        if ($TemplateText -notmatch "variables\s{0,}\(\s{0,}'$($Variable.Name)'\s{0,}\)") {
             Write-Error -Message "Unreferenced variable: $($Variable.Name)" -ErrorId Variables.Must.Be.Referenced -TargetObject $variable
         }
         


### PR DESCRIPTION
Fixing by simplifying: no longer attempting to match a reference before the parameter/variable start