### PR TITLE
Find-JsonContent bugfix

### DIFF
--- a/arm-ttk/Find-JsonContent.ps1
+++ b/arm-ttk/Find-JsonContent.ps1
@@ -68,7 +68,7 @@
                 $OutObject[$prop.Name] = $prop.Value
             }
             $OutObject['ParentObject'] = $parent
-            $OutObject['PropertyName'] = $Property[-1]
+            $OutObject['PropertyName'] = if ($property) {$Property[-1]}
 
             $OutObject['JSONPath']     = @(
                 $np =0

--- a/arm-ttk/Find-JsonContent.ps1
+++ b/arm-ttk/Find-JsonContent.ps1
@@ -4,49 +4,49 @@
     .Synopsis
         Finds content within a json object
     .Description
-        Recursively finds content within a json object 
+        Recursively finds content within a json object
     #>
     param(
     # The input object
     [Parameter(Mandatory=$true,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
     [PSObject]
     $InputObject,
-    
+
     # The key (the name of the property) we're finding.
     [Parameter(Mandatory=$true,ParameterSetName='Key',Position=0,ValueFromPipelineByPropertyName=$true)]
     [Parameter(Mandatory=$true,ParameterSetName='KeyValue',Position=0,ValueFromPipelineByPropertyName=$true)]
     [string]
     $Key,
-    
-    # The value we're trying to find. 
+
+    # The value we're trying to find.
     [Parameter(Mandatory=$true,ParameterSetName='KeyValue',Position=1,ValueFromPipelineByPropertyName=$true)]
     [PSObject]
     $Value,
-    
+
     # If set, will find values like the wildcard.
     [Parameter(ParameterSetName='Key',ValueFromPipelineByPropertyName=$true)]
     [Parameter(ParameterSetName='KeyValue',ValueFromPipelineByPropertyName=$true)]
     [switch]
     $Like,
-    
+
     # If set, will find values that match the regular expression.
     [Parameter(ParameterSetName='Key',ValueFromPipelineByPropertyName=$true)]
     [Parameter(ParameterSetName='KeyValue',ValueFromPipelineByPropertyName=$true)]
     [switch]
     $Match,
-    
+
     # If set, will find values that are not like a wildcard.
     [Parameter(ParameterSetName='Key',ValueFromPipelineByPropertyName=$true)]
     [Parameter(ParameterSetName='KeyValue',ValueFromPipelineByPropertyName=$true)]
     [switch]
     $NotLike,
-    
+
     # If set, will find values that do not match a regular expression.
     [Parameter(ParameterSetName='Key',ValueFromPipelineByPropertyName=$true)]
     [Parameter(ParameterSetName='KeyValue',ValueFromPipelineByPropertyName=$true)]
     [switch]
     $NotMatch,
-    
+
     # A list of parent objects.  This parameter will be passed recursively.
     [PSObject[]]
     $Parent,
@@ -62,16 +62,16 @@
     begin {
         $OutputMatch = {
             param([Parameter(Mandatory)][PSObject]$in)
-            
+
             $OutObject = [Ordered]@{}
             foreach ($prop in $in.psobject.properties) {
                 $OutObject[$prop.Name] = $prop.Value
             }
-            $OutObject['ParentObject'] = $parent  
+            $OutObject['ParentObject'] = $parent
             $OutObject['PropertyName'] = $Property[-1]
-            
+
             $OutObject['JSONPath']     = @(
-                $np =0 
+                $np =0
                 foreach ($p in $property) {
                     if ($p.StartsWith('[') -or -not $np) {
                         $p
@@ -88,82 +88,69 @@
         $mySplat = @{} + $PSBoundParameters
         $mySplat.Remove('InputObject')
         if (-not $InputObject) { return }
-            
+
 
         $index = -1
         foreach ($in in $InputObject) {
-            if (-not $in) { continue } 
+            if (-not $in) { continue }
             $index++
-            if ($in -is [string] -or $in -is [int] -or $in -is [bool] -or 
+            if ($in -is [string] -or $in -is [int] -or $in -is [bool] -or
                 $in -is [double] -or $in -is [long] -or $in -is [float]) {
                 continue
             }
 
             if ($PSCmdlet.ParameterSetName -eq 'KeyValue') {
                 if ($in.psobject.properties.item($key)) {
-                    if (($like -and $in.$key -like $Value) -or 
+                    if (($like -and $in.$key -like $Value) -or
                         ($Match -and $in.$key -match $Value) -or
-                        ($NotLike -and $in.$key -notlike $Value) -or 
-                        ($NotMatch -and $in.$key -notmatch $Value) -or 
+                        ($NotLike -and $in.$key -notlike $Value) -or
+                        ($NotMatch -and $in.$key -notmatch $Value) -or
                         ($in.$key -eq $Value -and -not ($NotLike -or $NotMatch))) {
-                        $OutObject = [Ordered]@{}
-                        foreach ($prop in $in.psobject.properties) {
-                            $OutObject[$prop.Name] = $prop.Value
-                        }
-                        $OutObject['ParentObject'] = $parent
-                        $OutObject['PropertyName'] = $Property[-1]
-                        $OutObject['JSONPath']     = @(
-                        $np =0 
-                        foreach ($p in $property) {
-                            if ($p.StartsWith('[') -or -not $np) {
-                                $p
-                            } else {
-                                ".$p"
-                            }
-                            $np++
-                        }) -join ''
-                        [PSCustomObject]$OutObject
+                        $property += $key
+                        . $outputMatch $in
                     }
                 }
             } elseif ($PSCmdlet.ParameterSetName -eq 'Key') {
                 $propertyNames = @(foreach ($_ in $in.psobject.properties) { $_.Name })
                 if (($Like -and $propertyNames -like $key) -or
-                    ($Match -and $propertyNames -match $key) -or 
+                    ($Match -and $propertyNames -match $key) -or
                     ($propertyNames -eq $key -and -not ($NotLike -or $NotMatch)))
                 {
-                    $matchingKeys = 
+                    $matchingKeys =
                         @(if ($like) {
-                            $propertyNames -like $key 
+                            $propertyNames -like $key
                         } elseif ($match) {
                             $propertyNames -match $key
                         } else {
-                            $key  
+                            $key
                         }) -join ','
                     $property += $matchingKeys
                     . $OutputMatch $in
-                } 
+                }
                 elseif (
-                    ($NotMatch -and $propertyNames -notmatch $Key) -or 
+                    ($NotMatch -and $propertyNames -notmatch $Key) -or
                     ($NotLike -and $propertyNames -notlike $Key)
-                ) 
-                {                    
+                )
+                {
                     . $OutputMatch $in
                 }
             }
 
-                
-            if ($parent -contains $in) { continue } 
+
+            if ($parent -contains $in) {
+                continue
+            }
             $mySplat.Parent = @($in) + $Parent
 
             if ($depth -and $mySplat.Parent.Length -ge $Depth) {
-                continue 
+                continue
             }
-        
+
             if ($in -is [Object[]]) {
-                
+
                 Find-JsonContent @mySplat -InputObject $in
             } else {
-                $propertyAndIndex = 
+                $propertyAndIndex =
                     @(if ($Property) {
                         $property
                     }
@@ -171,14 +158,14 @@
                         "[$index]"
                     })
                 foreach ($prop in $in.psobject.properties) {
-                    if (-not $prop.Value) { continue } 
+                    if (-not $prop.Value) { continue }
                     if ($prop.Name -like 'parent*') { continue }
                     $mySplat.Property = $propertyAndIndex + $prop.Name
-                    
-                      
-                    Find-JsonContent @mySplat -InputObject $prop.Value 
+
+
+                    Find-JsonContent @mySplat -InputObject $prop.Value
                 }
             }
         }
     }
-} 
+}


### PR DESCRIPTION
It looks like the problem was there was no parent object (are using $templateObject.Resources | Find-JsonContent in the apiVersions test).

Fixed in three ways:
* We guard against a null property now
* We populate the $Property for a -Key -Value match when we match (the other fix only covered -Key)
* We switch to a common codepath for all three scenarios.