### PR TITLE
Change command to check item is a file

### DIFF
--- a/arm-ttk/Expand-AzTemplate.ps1
+++ b/arm-ttk/Expand-AzTemplate.ps1
@@ -115,7 +115,7 @@
                 # If the template path doesn't appear to be a path to a json file,
                 if ($TemplatePath -notlike '*.json') {
                     # see if it looks like a file
-                    if (($templatePath | Split-Path -Leaf) -like '*.*') {
+                    if ( test-path -path $templatePath -PathType leaf) {
                         $TemplatePath = $TemplatePath | Split-Path # if it does, reassign template path to it's directory.
                     }
                     # Then, go looking beneath that template path


### PR DESCRIPTION
The command used to try and check if $templatePath is a file gives a false positive if the folder name has a period in it. I have updated the command to check for an actual file rather than using the name.