### PR TITLE
Find-JSONContent now returns each matching property as a unique string.

### DIFF
--- a/arm-ttk/Find-JsonContent.ps1
+++ b/arm-ttk/Find-JsonContent.ps1
@@ -123,7 +123,7 @@
                             $propertyNames -match $key
                         } else {
                             $key
-                        }) -join ','
+                        })
                     $property += $matchingKeys
                     . $OutputMatch $in
                 }


### PR DESCRIPTION
Fixing #67 