### PR TITLE
Variable reference fix 116

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Variables-Must-Be-Referenced.test.ps1
@@ -44,7 +44,7 @@ foreach ($variable in $TemplateObject.variables.psobject.properties) {
     
     # TODO: if the variable name is "copy": we need to loop through the array and pull each var and check individually
     
-    if ($variable.name -ne 'copy' -and -not $variable.value.copy) {        
+    if ($variable.name -ne 'copy' -and $variable.value.copy -eq $null) {        
         $foundRefs = @(& $findVariableInTemplate $variable.Name)
         if (-not $foundRefs) {
             Write-Error -Message "Unreferenced variable: $($Variable.Name)" -ErrorId Variables.Must.Be.Referenced -TargetObject $variable

--- a/unit-tests/Variables-Must-Be-Referenced/Pass/Variable-List-Value.json
+++ b/unit-tests/Variables-Must-Be-Referenced/Pass/Variable-List-Value.json
@@ -1,0 +1,19 @@
+﻿{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "parameters": {
+        "foo": {
+            "type": "string",
+            "defaultValue": "[variables('foo')]"
+        }
+    },
+    "variables": {
+        "foo": [
+            {
+                "bar": 1
+            },
+            {
+                "bar": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Fix for #116 

When the variable value was a list, it was incorrectly assuming it should be a copy variable.