### PR TITLE
Updated allowedExpressions to include additional 'Id' parameters

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -74,7 +74,12 @@ foreach ($id in $ids) { # Then loop over each object with an ID
         "reference",
         "variables",
         "subscription",
-        "guid"
+        "guid",
+        "servicePrincipalClientId",
+        "clientId",
+        "appId",
+        "tenantId",
+        "objectId"
     )
 
     # Check that it uses one of the allowed expressions - can remove variables once Expand-Template does full eval of nested vars


### PR DESCRIPTION
Added the following to the allowedExpressions hash table 

```
"servicePrincipalClientId",
"clientId",
"appId",
"tenantId",
"objectId"
```