### PR TITLE
Limit check to virtualMachines and virtualMachineScaleSets

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Virtual-Machines-Should-Not-Be-Preview.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Virtual-Machines-Should-Not-Be-Preview.test.ps1
@@ -10,7 +10,7 @@ param(
 $TemplateObject
 )
 
-$storageProfiles = Find-JsonContent -Key storageProfile -InputObject $TemplateObject
+$storageProfiles = Find-JsonContent -Key storageProfile -InputObject $TemplateObject | Where-Object {$_.ParentObject.type -eq "Microsoft.Compute/virtualMachines" -or $_.ParentObject.type -eq "Microsoft.Compute/virtualMachineScaleSets"}
 
 foreach ($sp in $storageProfiles) {
     $storageProfile = $sp.StorageProfile

--- a/unit-tests/Virtual-Machines-Should-Not-Be-Preview/Pass/hdi-cluster-storage-profile.json
+++ b/unit-tests/Virtual-Machines-Should-Not-Be-Preview/Pass/hdi-cluster-storage-profile.json
@@ -1,0 +1,25 @@
+{
+   "$schema":"https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion":"1.0.0.0",
+   // this case is taken from https://github.com/Azure/azure-quickstart-templates/blob/master/101-machine-learning-compute-attach-hdi/prereqs/prereq.azuredeploy.json
+   "resources":[
+      {
+         "name":"test",
+         "type":"Microsoft.HDInsight/clusters",
+         "location":"test",
+         "apiVersion":"2018-06-01-preview",
+         "properties":{
+            "storageProfile":{
+               "storageaccounts":[
+                  {
+                     "name":"[replace(replace(concat(reference(resourceId('Microsoft.Storage/storageAccounts', 'foo')).primaryEndpoints.blob),'https:',''),'/','')]",
+                     "isDefault":true,
+                     "container":"test",
+                     "key":"[listKeys(resourceId('Microsoft.Storage/storageAccounts', 'foo'), '2019-06-01').keys[0].value]"
+                  }
+               ]
+            }
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Currently the check will trigger a false positive if a variable or parameter is named 'storageProfile'.  Add a check to filter the results from Find-JsonContent to only include nodes where the parent object is a VM or VMSS.  Testing done: Tested script locally with vm and vmss templates manually modified to include "-preview" in the version field.  This might introduce a limitation of not finding cases where a variable named 'storageProfile' is defined and actually contains an 'imageReference', which is later used as the value for the 'storageProfile' field of a VM or VMSS.  This should also address https://github.com/Azure/arm-ttk/issues/122 which I'm guessing is happening because the prereq template for the HDI cluster includes a storageProfile property (https://github.com/Azure/azure-quickstart-templates/blob/master/101-machine-learning-compute-attach-hdi/prereqs/prereq.azuredeploy.json#L197) as will any other template that deploys HDInsight.