### PR TITLE
Allowed 'allowedCallerIpAddresses' to be Blank

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
@@ -24,12 +24,12 @@ $emptyItems = @([Regex]::Matches($TemplateText, "${colon}\{\s{0,}\}")) + # Empty
 $lineBreaks = [Regex]::Matches($TemplateText, "`n|$([Environment]::NewLine)")
 
 # Some properties can be empty for readability
-$PropertiesThatCanBeEmpty = 'resources', 
-                            'outputs', 
-                            'variables', 
-                            'parameters', 
-                            'functions', 
-                            'properties', 
+$PropertiesThatCanBeEmpty = 'resources',
+                            'outputs',
+                            'variables',
+                            'parameters',
+                            'functions',
+                            'properties',
                             'defaultValue', # enables optional parameters
                             'accessPolicies',  # keyVault requires this
                             'value', # Microsoft.Resources/deployments - passing empty strings to a nested deployment
@@ -37,6 +37,7 @@ $PropertiesThatCanBeEmpty = 'resources',
                             'inputs', # Microsoft.Portal/dashboard
                             'notEquals', # Microsoft.Authorization/policyDefinitions policyRule'
                             'clientId' # Microsoft.ContainerService/managedClusters.properties.servicePrincipalProfile
+                            'allowedCallerIpAddresses' # Microsoft.Logic/workflows Access Control
 
 if ($emptyItems) {
     foreach ($emptyItem in $emptyItems) {


### PR DESCRIPTION
regarding #167
This allowes the Access control property 'allowedCallerIpAddresses' to be empty.

- Added allowedCallerIpAddresses
- remove white spaces