### PR TITLE
CreateUiDefinition-Must-Not-Have-Blanks fix

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/CreateUIDefinition-Must-Not-Have-Blanks.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/CreateUIDefinition-Must-Not-Have-Blanks.test.ps1
@@ -16,10 +16,13 @@ $CreateUIDefinitionText
 
 $colon = "(?<=:)\s{0,}" # this a back reference for a colon followed by 0 to more whitespace
 
-$emptyItems = @([Regex]::Matches($CreateUIDefinitionText, "${colon}\{\s{0,}\}")) + # Empty objects
-              @([Regex]::Matches($CreateUIDefinitionText, "${colon}\[\s{0,}\]")) + # empty arrays
-              @([Regex]::Matches($CreateUIDefinitionText, "${colon}`"\s{0,}`"")) + # empty strings
-              @([Regex]::Matches($CreateUIDefinitionText, "${colon}null"))
+$emptyItems = 
+    @([Regex]::Matches($CreateUIDefinitionText, "${colon}\{\s{0,}\}")) + # Empty objects
+    @([Regex]::Matches($CreateUIDefinitionText, "${colon}\[\s{0,}\]")) + # empty arrays
+    @([Regex]::Matches($CreateUIDefinitionText, "${colon}`"\s{0,}`"")) + # empty strings
+    @([Regex]::Matches($CreateUIDefinitionText, "${colon}\[\s{0,}\{\s{0,}\}\s{0,}\]")) + # empty arrays containing empty objects 
+    @([Regex]::Matches($CreateUIDefinitionText, "${colon}\[\s{0,}`"\s{0,}`"\s{0,}\]")) + # empty arrays containing empty objects  
+    @([Regex]::Matches($CreateUIDefinitionText, "${colon}null"))
 
 $lineBreaks = [Regex]::Matches($CreateUIDefinitionText, "`n|$([Environment]::NewLine)")
 

--- a/unit-tests/CreateUIDefinition-Must-Not-Have-Blanks/Fail/CreateUIDefinition-With-EmptyObject/createUiDefinition.json
+++ b/unit-tests/CreateUIDefinition-Must-Not-Have-Blanks/Fail/CreateUIDefinition-With-EmptyObject/createUiDefinition.json
@@ -3,7 +3,7 @@
     "handler": "Microsoft.Azure.CreateUIDef",
     "version": "0.1.2-preview",
     "parameters": {
-        "basics": [
+        "foo": [
             {}
         ]
     }


### PR DESCRIPTION
Flagging empty object/string within otherwise empty array.
Fixing test case so that the empty item is not in basics, where empty items are permitted.