### PR TITLE
Renaming .ezformat file 

### DIFF
--- a/arm-ttk/arm-ttk.format.ps1xml
+++ b/arm-ttk/arm-ttk.format.ps1xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-16"?>
+﻿<?xml version="1.0" encoding="utf-16"?>
 <!-- Generated with EZOut 1.8.3.1: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <ViewDefinitions>
@@ -48,7 +48,7 @@ $($ParentNode.CustomControl.CustomEntries.CustomEntry.CustomItem.ExpressionBindi
         $global:_LastHistoryId = $h
     }
 
-    $CanUseColor = $host.UI.SupportsVirtualTerminal -and -not $ENV:AGENT_ID
+    $CanUseColor = $host.UI.SupportsVirtualTerminal -and -not $ENV:AGENT_ID -and -not $env:GITHUB_RUN_ID
     
 
     if ($global:_LastFile -ne $testOut.File.FullPath) {
@@ -108,8 +108,14 @@ $($ParentNode.CustomControl.CustomEntries.CustomEntry.CustomItem.ExpressionBindi
         Write-Host $statusLine -NoNewline -ForegroundColor $foregroundColor
     }
 
-    $azoErrorStatus = if ($ENV:Agent_ID) { "##[error]"} else { '' }
-    $azoWarnStatus  = if ($ENV:Agent_ID) { "##[warning]"} else { '' }
+    $azoErrorStatus = 
+        if ($ENV:Agent_ID) { "##[error]"} 
+        elseif ($env:GITHUB_RUN_ID) {"::error::" }
+        else { '' }
+    $azoWarnStatus  = 
+        if ($ENV:Agent_ID) { "##[warning]"} 
+        elseif ($env:GITHUB_RUN_ID) {"::warning::" }
+        else { '' }
     $indent = 8
     if ($testOut.AllOutput) {
         if (-not $CanUseColor) {

--- a/arm-ttk/ttk.ezformat.ps1
+++ b/arm-ttk/ttk.ezformat.ps1
@@ -1,9 +1,8 @@
-#requires -Module EZOut
+﻿#requires -Module EZOut
 #                 https://github.com/StartAutomating/EZOut
-#              OR Install-Module EZOut   
+#              OR Install-Module EZOut
 $myRoot = $MyInvocation.MyCommand.ScriptBlock.File | Split-Path
 $myName = 'arm-ttk'
-
 
 Write-FormatView -Action {
     $testOut = $_
@@ -17,12 +16,12 @@ Write-FormatView -Action {
     }
 
     $CanUseColor = $host.UI.SupportsVirtualTerminal -and -not $ENV:AGENT_ID
-    
+
 
     if ($global:_LastFile -ne $testOut.File.FullPath) {
         $msg = "Validating $($testOut.File.FullPath | Split-Path | split-Path -Leaf)\$($testOut.File.Name)"
         if ($CanUseColor) {
-            . $SetOutputStyle -ForegroundColor Magenta        
+            . $SetOutputStyle -ForegroundColor Magenta
             $msg + [Environment]::NewLine
             . $clearOutputStyle
         } else {
@@ -46,7 +45,7 @@ Write-FormatView -Action {
     $foregroundColor = 'Green'
     $statusChar = '+'
 
-    
+
     $errorLines = @(
         foreach ($_ in $testOut.Errors) {
             "$_"
@@ -57,16 +56,16 @@ Write-FormatView -Action {
         }
     )
 
-    
+
 
     if ($errorCount) {
         $foregroundColor = if ($CanUseColor) { 'Error' } else { 'Red' }
-        $statusChar = '-'        
+        $statusChar = '-'
     } elseif ($warningCount) {
-        $foregroundColor = if ($CanUseColor) { 'Warning' } else { 'Yellow' } 
-        $statusChar = '?'        
+        $foregroundColor = if ($CanUseColor) { 'Warning' } else { 'Yellow' }
+        $statusChar = '?'
     }
-    
+
     $statusLine = "    [$statusChar] $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
     if ($CanUseColor) {
         . $setOutputStyle -ForegroundColor $foregroundColor
@@ -84,7 +83,7 @@ Write-FormatView -Action {
             Write-Host ' '
         } else {
             [Environment]::NewLine
-        } 
+        }
         foreach ($line in $testOut.AllOutput) {
             if ($line -is [Management.Automation.ErrorRecord] -or $line -is [Exception]) {
                 $msg = "$azoErrorStatus$(' ' * $indent)$line"
@@ -107,7 +106,7 @@ Write-FormatView -Action {
                     $msg + [Environment]::NewLine
                     . $clearOutputStyle
                 } else {
-                    Write-Host -ForegroundColor Yellow $msg 
+                    Write-Host -ForegroundColor Yellow $msg
                 }
             }
             elseif ($line -is [string]) {
@@ -119,7 +118,7 @@ Write-FormatView -Action {
                 }
             }
             else {
-                $line | 
+                $line |
                     Out-String -Width ($Host.UI.RawUI.BufferSize.Width - $indent) |
                     & { process {
                         if ($CanUseColor) {
@@ -127,7 +126,7 @@ Write-FormatView -Action {
                         } else {
                             Write-Host "$(' ' * $indent)$_"
                         }
-                    } } 
+                    } }
             }
         }
     }) -join ''


### PR DESCRIPTION
(avoiding it being counted for coverage, which produces odd errors).