### PR TITLE
Support UIDefinition.TextBox.constraints.validations

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1
@@ -5,10 +5,10 @@
     Ensures that TextBox controls are well formed, including having a validation Regular Expression.
 #>
 param(
-# The contents of CreateUIDefintion, converted from JSON.
-[Parameter(Mandatory=$true,Position=0)]
-[PSObject]
-$CreateUIDefinitionObject
+    # The contents of CreateUIDefintion, converted from JSON.
+    [Parameter(Mandatory = $true, Position = 0)]
+    [PSObject]
+    $CreateUIDefinitionObject
 )
 
 # First, find all textboxes within CreateUIDefinition.
@@ -16,27 +16,49 @@ $CreateUIDefinitionObject
 $allTextBoxes = $CreateUiDefinitionObject | Find-JsonContent -Key type -value Microsoft.Common.TextBox
 $lengthConstraintRegex = [Regex]::new('\{(?<Min>\d+),(?<Max>\d+)?\}(\$)?$')
 
-foreach ($textbox in $allTextBoxes) { # Then we walk over each textbox.
-    if (-not $textbox.constraints) { # If constraints was missing or blank,
+foreach ($textbox in $allTextBoxes) {
+    # Then we walk over each textbox.
+    if (-not $textbox.constraints) {
+        # If constraints was missing or blank,
         Write-Error "Textbox $($textbox.Name) is missing constraints" -TargetObject $textbox # error
         continue # and continue (since additional failures would be noise).
-    }    
-    if (-not $textbox.constraints.regex) { # If the constraint didn't have a regex,
-        Write-Error "Textbox $($textbox.Name) is missing constraints.regex" -TargetObject $textbox #error.
-    } else {        
-        try { # If it did,
-            $constraintWasRegex = [Regex]::new($textbox.constraints.regex) # try to cast to a regex
-            $hasLengthConstraint = $lengthConstraintRegex.Match($textbox.constraints.regex)
-
+    }
+    $constraintWasRegexString = "";
+    if ($textbox.constraints.validations) {
+        foreach ($validation in $textbox.constraints.validations) {
+            if ($validation.regex) {
+                $constraintWasRegexString = $validation.regex
+            }
+            if (-not $validation.message) {
+                # If there's not a validation message
+                Write-Error "Textbox $($textbox.Name) is missing validation message in constraints.validations items" -TargetObject $textbox #error.
+            }
+        }
+    }
+    elseif ($textbox.constraints.regex) {
+        $constraintWasRegexString = $textbox.constraints.regex
+        if (-not $textbox.constraints.validationMessage) {
+            # If there's not a validation message
+            Write-Error "Textbox $($textbox.Name) is missing constraints.validationMessage" -TargetObject $textbox #error.
+        }
+    }
+    if (-not $constraintWasRegexString ) {
+        # If the constraint didn't have a regex,
+        Write-Error "Textbox $($textbox.Name) is missing constraints.regex or regex property in constraints.validations items" -TargetObject $textbox #error.
+    }
+    else {
+        try {
+            # If it did,
+            $constraintWasRegex = [Regex]::new($constraintWasRegexString) # try to cast to a regex
+            $hasLengthConstraint = $lengthConstraintRegex.Match($constraintWasRegexString)
+    
             if (-not $hasLengthConstraint.Success) {
                 Write-Warning "TextBox '$($textBox.Name)' regex does not have a length constraint." 
             }
-        } catch {
+        }
+        catch {
             $err = $_ # if that fails, 
             Write-Error "Textbox $($textbox.Name) regex is invalid: $($err)" -TargetObject $textbox #error.
         }
-    }
-    if (-not $textbox.constraints.validationMessage) { # If there's not a validation message
-        Write-Error "Textbox $($textbox.Name) is missing constraints.validationMessage" -TargetObject $textbox #error.
     }
 }

--- a/arm-ttk/testcases/CreateUIDefinition/Validations-Must-Have-Message.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Validations-Must-Have-Message.test.ps1
@@ -1,0 +1,34 @@
+<#
+.Synopsis
+    Ensures that validations in CreateUIDefinition controls have message in each item.
+.Description
+    Ensures that validations in CreateUIDefinition controls have message in each item.
+#>
+param(
+    # The contents of CreateUIDefintion, converted from JSON.
+    [Parameter(Mandatory = $true, Position = 0)]
+    [PSObject]
+    $CreateUIDefinitionObject
+)
+
+# Find any item property in CreateUIDefinition that uses validations
+$constraints = @($CreateUIDefinitionObject | 
+    Find-JsonContent -Key validations -Value * -Like)
+foreach ($cobj in $constraints) {
+    # Walk thru each thing we find.
+    # First we need to find the control
+    $parent = $cobj.ParentObject[0]
+    $messageKey = 'message'
+
+    foreach ($item in $cobj.validations) {
+        if (-not $item.psobject.properties.Item($messageKey)) {
+            # Find the item name
+            $key = foreach ($object_properties in $item.PsObject.Properties) {
+                if ($object_properties.Name -ne $messageKey) { 
+                    $object_properties.Name; break
+                }
+            }
+            Write-Error -Message "Validations property in $($parent.Name) is missing message for $($key)." -ErrorId Validations.Must.Have.Message -TargetObject $parent #error.
+        }
+    }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex-Validations/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex-Validations/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex-Validations/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex-Validations/createUiDefinition.json
@@ -5,14 +5,18 @@
     "parameters": {
         "basics": [
             {
-                "name": "TextBox1",
+                "name": "TextBox2",
                 "type": "Microsoft.Common.TextBox",
                 "label": "Textboxes With Invalid Regex",
                 "toolTip": "Textboxes with invalid regex.",
                 "constraints": {
                     "required": true,
-                    "regex": "^hel($",
-                    "validationMessage": "Textboxes with invalid regex in constraints.regex."
+                    "validations": [
+                        {
+                            "regex": "^hel($",
+                            "message": "Textboxes with invalid regex in constraints.validations."
+                        }
+                    ]
                 }
             }
         ],

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-With-Invalid-Regex/createUiDefinition.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes With Invalid Regex",
+                "toolTip": "Textboxes with invalid regex.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^hel($",
+                    "validationMessage": "Textboxes with invalid regex in constraints.regex."
+                }
+            },
+            {
+                "name": "TextBox2",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes With Invalid Regex",
+                "toolTip": "Textboxes with invalid regex.",
+                "constraints": {
+                    "required": true,
+                    "validations": [
+                        {
+                            "regex": "^hel($",
+                            "message": "Textboxes with invalid regex in constraints.validations."
+                        }
+                    ]
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Constrains-ValidationMessage/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Constrains-ValidationMessage/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Constrains-ValidationMessage/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Constrains-ValidationMessage/createUiDefinition.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes Without Constrains ValidationMessage",
+                "toolTip": "Textboxes without constrains.validationMessage.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^[0-9]+$"
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Regex/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Regex/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Fail/Textboxes-Without-Regex/createUiDefinition.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes Without Regex",
+                "toolTip": "Textboxes without regex.",
+                "constraints": {
+                    "required": true
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Regex/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Regex/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Regex/createUiDefinition.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes-With-Constrains-Regex",
+                "toolTip": "Textboxes with constraints.regex.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^[0-9]+$",
+                    "validationMessage": "Textboxes with constraints.regex."
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Validations/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Validations/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Validations/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Constrains-Validations/createUiDefinition.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes-With-Constrains-Validations",
+                "toolTip": "Textboxes with constraints.validations.",
+                "constraints": {
+                    "required": true,
+                    "validations": [
+                        {
+                            "regex": "^[0-9]+$",
+                            "message": "Textboxes with constraints.validations."
+                        }
+                    ]
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Validations-Must-Have-Message/Fail/Validations-Without-Message/azuredeploy.json
+++ b/unit-tests/Validations-Must-Have-Message/Fail/Validations-Without-Message/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Validations-Must-Have-Message/Fail/Validations-Without-Message/createUiDefinition.json
+++ b/unit-tests/Validations-Must-Have-Message/Fail/Validations-Without-Message/createUiDefinition.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Validations-Without-Message",
+                "toolTip": "Validations without message.",
+                "constraints": {
+                    "required": true,
+                    "validations": [
+                        {
+                            "regex": "^[0-9]+$"
+                        }
+                    ]
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Validations-Must-Have-Message/Pass/Validation-With-Message/azuredeploy.json
+++ b/unit-tests/Validations-Must-Have-Message/Pass/Validation-With-Message/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Validations-Must-Have-Message/Pass/Validation-With-Message/createUiDefinition.json
+++ b/unit-tests/Validations-Must-Have-Message/Pass/Validation-With-Message/createUiDefinition.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Validations-With-Message",
+                "toolTip": "Validations with message.",
+                "constraints": {
+                    "required": true,
+                    "validations": [
+                        {
+                            "regex": "^[0-9]+$",
+                            "message": "Validations with message."
+                        }
+                    ]
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}


### PR DESCRIPTION
For issue: https://github.com/Azure/arm-ttk/issues/208.

modified: arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1
Support constraints.validations schema.

Testcase:
1. textbox without regex, throw error message: `Textbox $($textbox.Name) is missing constraints.regex or regex property in constraints.validations items`
2. textbox with constraints.regex, test length constraint
3. textbox with constraints.validations[i].regex, test length constraint
4. text validation message.