### PR TITLE
Adding concat as a valid expression

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -82,7 +82,8 @@ foreach ($id in $ids) { # Then loop over each object with an ID
         "clientId",
         "appId",
         "tenantId",
-        "objectId"
+        "objectId",
+        "concat"
     )
 
     # Check that it uses one of the allowed expressions - can remove variables once Expand-Template does full eval of nested vars


### PR DESCRIPTION
Concatenation of strings can be used when refering custom policies.

An example could be a custom policy created with a friendly name such as "Test-Policy1"
Then a concatenation of the policy could be SCOPE/providers/Microsoft.Authorization/policyDefinitions/Test-Policy1
Where the scope could be something like:
/providers/Microsoft.Management/managementGroups/ITManagementGroup

We use this in our ARM template and currently validation fails at this step, so either it should be in the exclude section or also allow concat as a valid expression.