### PR TITLE
The vlanId in Microsoft.Network/expressRouteCircuits is not an resourceId

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -39,7 +39,8 @@ foreach ($id in $ids) { # Then loop over each object with an ID
         "clientId", # Microsoft.BotService - common var name
         "appId", # Microsoft.Insights
         "tenantId", # Common Property name
-        "objectId" # Common Property name
+        "objectId", # Common Property name
+        "vlanId" # Unique Id to establish peering when setting up an ExpressRoute circuit
     )
 
     if ($exceptions -contains $myIdFieldName) { # We're checking resource ids, not tenant IDs


### PR DESCRIPTION
The vlanId in Microsoft.Network/expressRouteCircuits is not an resourceId...

More info here: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-howto-routing-portal-resource-manager