### PR TITLE
Removing trafficmanager.net from DeploymentTemplate-Must-Not-Contain-Hardcoded-Uri

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/DeploymentTemplate-Must-Not-Contain-Hardcoded-Uri.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/DeploymentTemplate-Must-Not-Contain-Hardcoded-Uri.test.ps1
@@ -22,7 +22,7 @@ $DisallowedHosts =
         "login.microsoftonline.com",
         "graph.windows.net",
         "graph.windows.net",
-        "trafficmanager.net",
+        # "trafficmanager.net", # Removing this as it cannot be found in the ARM function [Environment()]
         "vault.azure.net",
         "datalake.azure.net",
         "azuredatalakestore.net",


### PR DESCRIPTION
Fixing #228 