### PR TITLE
Update to exclude policyDefinitionReferenceId on Ids should be derived from resourceids

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -43,6 +43,7 @@ foreach ($id in $ids) { # Then loop over each object with an ID
         "objectId", # Common Property name
         "vlanId", # Unique Id to establish peering when setting up an ExpressRoute circuit
         "SyntheticMonitorId" # Microsoft.Insights/webtests
+		"policyDefinitionReferenceId" # Microsft.Authorization/policySetDefinition unique Id used when setting up a PolicyDefinitionReference
     )
 
     if ($exceptions -contains $myIdFieldName) { # We're checking resource ids, not tenant IDs

--- a/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -42,8 +42,8 @@ foreach ($id in $ids) { # Then loop over each object with an ID
         "tenantId", # Common Property name
         "objectId", # Common Property name
         "vlanId", # Unique Id to establish peering when setting up an ExpressRoute circuit
-        "SyntheticMonitorId" # Microsoft.Insights/webtests
-		"policyDefinitionReferenceId" # Microsft.Authorization/policySetDefinition unique Id used when setting up a PolicyDefinitionReference
+        "SyntheticMonitorId", # Microsoft.Insights/webtests
+	"policyDefinitionReferenceId" # Microsft.Authorization/policySetDefinition unique Id used when setting up a PolicyDefinitionReference
     )
 
     if ($exceptions -contains $myIdFieldName) { # We're checking resource ids, not tenant IDs

--- a/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Pass/exceptions-that-should-pass.json
+++ b/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Pass/exceptions-that-should-pass.json
@@ -1,35 +1,36 @@
 ﻿{
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "resources": [
-        {
-            "id": "[resourceId('Microsoft.Storage/storageAccounts', 'name')]", //TODO this throws off the error message since we pull the parent's name (in this case 'variables')
-            "pass1": {
-                "id": "[ resourceId ( 'Microsoft.Network/applicationGateways/httpListeners', 'appGW', 'appGatewayHttpListener')]"
-            },
-            "pass2": {
-                "id": "[parameters ('appGatewayBackendPool')]"
-            },
-            "pass3": {
-                "id": "[variables('id')]"
-            },
-            "pass4": {
-                "id": "[subscriptionResourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-            },
-            "pass5": {
-                "id": "[ tenantResourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-            },
-            "pass6": {
-                "id": "[extensionResourceId( resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), 'Microsoft.Resources/type', 'resourceName')]"
-            },
-            "pass7": {
-                "id": "[resourceId(parameters('storageResourceGroupName'), 'Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
-            },
-            "pass8": {
-                "id": "[if(bool('true'), resourceId(parameters('storageResourceGroupName'), 'Microsoft.Storage/storageAccounts', parameters('storageAccountName')), json('null'))]"
-            },
-            "keyVaultSecretId": "[concat()]", // this is actually a uri Microsoft.Network/applicationGateways sslCertificates - created with reference() and concat /secrets/secretname
-            "storageAccountSubscriptionId": "[subscription().subscriptionId]", // Microsoft.Sql/servers/auditSettings asks for a subscriptionId
-            "roleAssignmentGuid": "[ guid ('some seed')]" // variables that are used for roleAssignment GUIDs (or any other guid) ends in "id" and should be exempted if the function is used
-        }
-    ]
+	"$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+	"resources": [
+		{
+			"id": "[resourceId('Microsoft.Storage/storageAccounts', 'name')]", //TODO this throws off the error message since we pull the parent's name (in this case 'variables')
+			"pass1": {
+				"id": "[ resourceId ( 'Microsoft.Network/applicationGateways/httpListeners', 'appGW', 'appGatewayHttpListener')]"
+			},
+			"pass2": {
+				"id": "[parameters ('appGatewayBackendPool')]"
+			},
+			"pass3": {
+				"id": "[variables('id')]"
+			},
+			"pass4": {
+				"id": "[subscriptionResourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+			},
+			"pass5": {
+				"id": "[ tenantResourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+			},
+			"pass6": {
+				"id": "[extensionResourceId( resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), 'Microsoft.Resources/type', 'resourceName')]"
+			},
+			"pass7": {
+				"id": "[resourceId(parameters('storageResourceGroupName'), 'Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+			},
+			"pass8": {
+				"id": "[if(bool('true'), resourceId(parameters('storageResourceGroupName'), 'Microsoft.Storage/storageAccounts', parameters('storageAccountName')), json('null'))]"
+			},
+			"keyVaultSecretId": "[concat()]", // this is actually a uri Microsoft.Network/applicationGateways sslCertificates - created with reference() and concat /secrets/secretname
+			"storageAccountSubscriptionId": "[subscription().subscriptionId]", // Microsoft.Sql/servers/auditSettings asks for a subscriptionId
+			"roleAssignmentGuid": "[ guid ('some seed')]", // variables that are used for roleAssignment GUIDs (or any other guid) ends in "id" and should be exempted if the function is used
+			"policyDefinitionReferenceId": "some value" // Microsoft.Authorization/policySetDefinitions allows policyDefinitionReferenceId to be "A unique id (within the policy set definition) for this policy definition reference."
+		}
+	]
 }


### PR DESCRIPTION
I found while running the tests on one of my arm templates that it would error due to policyDefinitionReferenceId not being right.

https://docs.microsoft.com/en-us/azure/templates/microsoft.authorization/policysetdefinitions specifies PolicyDefinitionReference.policyDefinitionReferenceId to be 'A unique id (within the policy set definition) for this policy definition reference.'

This pull request updates the exclusion list to include the policyDefinitionReferenceId so it is not incorrectly flagged up.