### PR TITLE
When testing for presence of length constraint, test at beginning of regex as well.

### DIFF
--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes-With-Constrains-Validations",
+                "toolTip": "Textboxes with constraints.validations.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^[0-9]{5,10}$",
+                    "validationMessage": "Textboxes with constraints.regex contains length limits."
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-Without-Length-Constrains-Regex/azuredeploy.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-Without-Length-Constrains-Regex/azuredeploy.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+         "description": "Location for all resources."
+      }
+   }
+  },
+  "variables": {
+  },
+  "resources": [
+  ],
+  "outputs": {
+    "location": {
+      "type": "string",
+      "value": "[parameters('location')]"
+   }
+  }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-Without-Length-Constrains-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-Without-Length-Constrains-Regex/createUiDefinition.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes-With-Constrains-Validations",
+                "toolTip": "Textboxes with constraints.validations.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^[0-9]$",
+                    "validationMessage": "Textboxes with constraints.regex contains length limits."
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-Without-Length-Constrains-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-Without-Length-Constrains-Regex/createUiDefinition.json
@@ -11,6 +11,7 @@
                 "toolTip": "Textboxes with constraints.validations.",
                 "constraints": {
                     "required": true,
+                    // The reason for doing so is that usually the value users type in here will be passed directly to downstream as a parameter, and there is another constrain there really matters and the constrain varies from case to case.
                     "regex": "^[0-9]$",
                     "validationMessage": "Textboxes with constraints.regex contains length limits."
                 }


### PR DESCRIPTION
modified:   arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1

- When testing for presence of length constraint, test at beginning of regex as well.