### PR TITLE
fix apiVersion and preview version being the same

### DIFF
--- a/unit-tests/apiversions-should-be-recent/Fail/api-version-is-an-expression.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/api-version-is-an-expression.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "functions": [],
+    "variables": {},
+    "resources": [
+        {
+            "name": "publicIPAddress1",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "[concat('2020', '01-01')]",
+            "location": "[resourceGroup().location]",
+            "tags": {
+                "displayName": "publicIPAddress1"
+            },
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic"
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/unit-tests/apiversions-should-be-recent/Fail/not-a-string.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/not-a-string.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "functions": [],
+    "variables": {},
+    "resources": [
+        {
+            "name": "publicIPAddress1",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": true,
+            "location": "[resourceGroup().location]",
+            "tags": {
+                "displayName": "publicIPAddress1"
+            },
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic"
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/unit-tests/apiversions-should-be-recent/Fail/old-apiVersion.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/old-apiVersion.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "functions": [],
+    "variables": {},
+    "resources": [
+        {
+            "name": "publicIPAddress1",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "2015-06-15",
+            "location": "[resourceGroup().location]",
+            "tags": {
+                "displayName": "publicIPAddress1"
+            },
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic"
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/unit-tests/apiversions-should-be-recent/Fail/preview-when-newer-is-available.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/preview-when-newer-is-available.json
@@ -1,0 +1,17 @@
+{
+    "$schema":  "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "resources":  [
+    {
+      "apiVersion": "2017-12-01-preview",  // there also exists a 2017-12-01-preview apiVersion...
+      "type": "Microsoft.DBforMySQL/servers",
+      "name": "db]",
+      "location": "westeurope",
+      "properties": {
+        "administratorLogin": "sa",
+        "administratorLoginPassword": "don't put passwords in plain text",
+        "createMode": "Default",
+        "sslEnforcement": "Disabled"
+      }
+    }
+    ]
+}

--- a/unit-tests/apiversions-should-be-recent/Pass/apiManagmentHasAnApiVersionUnderProperties.json
+++ b/unit-tests/apiversions-should-be-recent/Pass/apiManagmentHasAnApiVersionUnderProperties.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.ApiManagement/service/apis",
+            "apiVersion": "2020-06-01-preview",
+            "name": "foo/bar",
+            "properties": {
+                "displayName": "test",
+                "apiRevision": "1",
+                "description": "Init",
+                "subscriptionRequired": true,
+                "path": "foo",
+                "protocols": [
+                    "https"
+                ],
+                "isCurrent": true,
+                "apiVersion": "v1", // this should not be flagged
+                "apiVersionSetId": "[resourceId('Microsoft.ApiManagement/service/apiVersionSets', 'foo', 'bar')]"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
When an apiVersion has a preview the matches the latest, we don't enforce the latest.  This should fix that...

Also added unit tests, we had very few so hard to track regressions.
