### PR TITLE
Fix broken output formatting in Azure Pipelines.

### DIFF
--- a/arm-ttk/arm-ttk.format.ps1xml
+++ b/arm-ttk/arm-ttk.format.ps1xml
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-16"?>
-<!-- Generated with EZOut 1.8.3.1: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
+<?xml version="1.0" encoding="utf-16"?>
+<!-- Generated with EZOut 1.8.4: Install-Module EZOut or https://github.com/StartAutomating/EZOut -->
 <Configuration>
   <ViewDefinitions>
     <View>
@@ -58,7 +58,7 @@ $($ParentNode.CustomControl.CustomEntries.CustomEntry.CustomItem.ExpressionBindi
             $msg + [Environment]::NewLine
             . ${arm-ttk_clearOutputStyle}
         } else {
-            Write-Host -ForegroundColor Magenta -NoNewline $msg
+            Write-Host -ForegroundColor Magenta $msg
         }
         $global:_LastFile = $testOut.File.FullPath
     }

--- a/arm-ttk/ttk.ezformat.ps1
+++ b/arm-ttk/ttk.ezformat.ps1
@@ -25,7 +25,7 @@ Write-FormatView -Action {
             $msg + [Environment]::NewLine
             . $clearOutputStyle
         } else {
-            Write-Host -ForegroundColor Magenta -NoNewline $msg
+            Write-Host -ForegroundColor Magenta $msg
         }
         $global:_LastFile = $testOut.File.FullPath
     }


### PR DESCRIPTION
I've changed `arm-ttk/ttk.ezformat.ps1` and regenerated `arm-ttk/arm-ttk.format.ps1xml`.