### PR TITLE
Add line number info to error's target objects

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
@@ -34,7 +34,9 @@ foreach ($parameter in $TemplateObject.parameters.psobject.properties) {
             $foundQuote =$exprStrOrQuote.Match($TemplateText, $fr.Index + 1) # make sure we hit a [ before a quote
             if ($foundQuote.Value -eq '"') { # if we don't, error
                 $lineNumber = @($lineBreaks | ? { $_.Index -lt $fr.Index }).Count + 1    
-                Write-Error -Message "Parameter reference is not contained within an expression: $($Parameter.Name) on line: $lineNumber" -ErrorId Parameters.Must.Be.Referenced.In.Expression -TargetObject $parameter
+                $targetObject = $parameter.PsObject.Copy()
+                $targetObject | Add-Member -MemberType NoteProperty -Name lineNumber -Value $lineNumber
+                Write-Error -Message "Parameter reference is not contained within an expression: $($Parameter.Name) on line: $lineNumber" -ErrorId Parameters.Must.Be.Referenced.In.Expression -TargetObject $targetObject
             }
         }
     }

--- a/arm-ttk/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
@@ -62,7 +62,9 @@ if ($emptyItems) {
                 continue
             }
             $lineNumber = @($lineBreaks | ? { $_.Index -lt $emptyItem.Index }).Count + 1
-            Write-Error "Empty property: $emptyItem found on line: $lineNumber" -TargetObject $emptyItem
+            $targetObject = $emptyItem.PsObject.Copy()
+            $targetObject | Add-Member -MemberType NoteProperty -Name lineNumber -Value $lineNumber
+            Write-Error "Empty property: $emptyItem found on line: $lineNumber" -TargetObject $targetObject
         } 
     }
 }


### PR DESCRIPTION
Line numbers are reported in three deploymentTemplate checks: ResourceIds-should-not-contain, Template-Should-Not-Contain-Blanks, and Parameters-Must-Be-Referenced. The first outputs as `TargetObject` an object with the value in its `lineNumber` property. Adding the same property for the output objects of the two remaining checks. It's needed for TTK's first integration into [template-analyzer](https://github.com/Azure/template-analyzer).