### PR TITLE
Added documentdb / sqldatabases exception

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -85,6 +85,11 @@ foreach ($id in $ids) {
         continue
     }
 
+    # Skip this check if id is inside resource property and type is Microsoft.DocumentDB/databaseAccounts/sqlDatabases
+    if ( $id.ParentObject.type -match '^Microsoft\.DocumentDB/databaseAccounts/sqlDatabases$' -and $id.JsonPath -match '\.(resource)\.' ) {
+        continue
+    }
+
     # skip resourceId check within tags #274
     if ( $id.JSONPath -match "\.(tags)\.($myIdFieldName)" ) { 
         continue 

--- a/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Fail/documentdb-sqldatabases-that-contains-invalid-id-property-should-fail.json
+++ b/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Fail/documentdb-sqldatabases-that-contains-invalid-id-property-should-fail.json
@@ -15,7 +15,7 @@
                 "resource": {
                     "id": "dbName"
                 },
-                "id": "this is is not excluded from verification"
+                "id": "this is not excluded from verification"
             }
         }
     ],

--- a/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Fail/documentdb-sqldatabases-that-contains-invalid-id-property-should-fail.json
+++ b/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Fail/documentdb-sqldatabases-that-contains-invalid-id-property-should-fail.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "functions": [],
+    "variables": {},
+    "resources": [
+        {
+            "name": "dbAccount/dbName",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+            "apiVersion": "2021-04-15",
+            "location": "eastus",
+            "tags": {},
+            "properties": {
+                "resource": {
+                    "id": "dbName"
+                },
+                "id": "this is is not excluded from verification"
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Pass/documentdb-sqldatabases-that-contains-resource-id-should-pass.json
+++ b/unit-tests/IDs-Should-Be-Derived-From-ResourceIDs/Pass/documentdb-sqldatabases-that-contains-resource-id-should-pass.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {},
+    "functions": [],
+    "variables": {},
+    "resources": [
+        {
+            "name": "dbAccount/dbName",
+            "type": "Microsoft.DocumentDB/databaseAccounts/sqlDatabases",
+            "apiVersion": "2021-04-15",
+            "location": "eastus",
+            "tags": {},
+            "properties": {
+                "resource": {
+                    "id": "dbName"
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}


### PR DESCRIPTION
This PR adds an exception to the following type: Microsoft.DocumentDB/databaseAccounts/sqlDatabases but only to resource.id property.

Added a negative test to test that any other id outside of 'resource' property bag should get flagged.