### PR TITLE
support 'managedIdentity' special parameter

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/Outputs-Must-Be-Present-In-Template-Parameters.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Outputs-Must-Be-Present-In-Template-Parameters.test.ps1
@@ -31,6 +31,7 @@ foreach ($output in $parameterInfo.outputs.psobject.properties) { # Then walk th
     $outputName = $output.Name
     if ($outputName -eq 'applicationresourcename' -or `
         $outputName -eq 'jitaccesspolicy' -or `
+        $outputName -eq 'managedidentity' -or `
         $outputName -eq 'managedresourcegroupid') { # If the output was one of the outputs used for Managed Apps and only found in the generated template, skip the test
             continue 
     }


### PR DESCRIPTION
Deploying a managed application with an assigned managed identity from the market place requires adding a special parameters 'managedIdenity' in the output section of the createUiDefinition.json file. This is a special parameter that exists only in the generated template and should be skip accordingly in the tests.