### PR TITLE
Fixing #385 (apiversion fix)

### DIFF
--- a/arm-ttk/Test-AzTemplate.ps1
+++ b/arm-ttk/Test-AzTemplate.ps1
@@ -254,7 +254,9 @@ Each test script has access to a set of well-known variables:
                         $usedParameters = $false
                         # Map TemplateText to the inner template text by converting to JSON (if the test command uses -TemplateText)
                         if ($testCommandParameters.ContainsKey("TemplateText")) { 
-                            $templateObject = $testInput['TemplateText']   = $ParentTemplateText.Substring($foundInnerTemplate.Index, $foundInnerTemplate.Length)
+                            $templateText   = $testInput['TemplateText']   = 
+                                $ParentTemplateText.Substring($foundInnerTemplate.Index, $foundInnerTemplate.Length) -replace 
+                                    '^[''"\w]+\s{0,}\:' # Clip the name of the property the template was embedded within, so $templateText is valid JSON
                             $usedParameters = $true
                         }
                         # And Map TemplateObject to the converted json (if the test command uses -TemplateObject)

--- a/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -46,10 +46,7 @@ if (-not $TemplateObject.resources) {
 }
 
 # First, find all of the API versions in the main template resources.
-$allApiVersions = $TemplateObject.resources | 
-Find-JsonContent -Key apiVersion -Value * -Like
-
-
+$allApiVersions = Find-JsonContent -Key apiVersion -Value * -Like -InputObject $TemplateObject.resources
 
 
 foreach ($av in $allApiVersions) {
@@ -63,7 +60,8 @@ foreach ($av in $allApiVersions) {
         apiVersion
     #>
 
-    if($av.jsonPath -ne "apiVersion" -and $av.jsonpath -notmatch "apiVersion\[\d+\]\.apiVersion"){
+    if($av.jsonPath -ne "apiVersion" -and 
+        $av.jsonpath -notmatch "apiVersion\[\d+\]\.apiVersion"){
         continue
     }
 


### PR DESCRIPTION
Because $templateObject.resources was being piped into Find-JSONContent, the JSONPath was returned with an unexpected pattern that missed multiple apis.