### PR TITLE
Resolve-JSONContent:  Fixes for Inner Template

### DIFF
--- a/arm-ttk/Expand-AzTemplate.ps1
+++ b/arm-ttk/Expand-AzTemplate.ps1
@@ -309,7 +309,7 @@ function Expand-AzTemplate
                 if (-not $anyProblems) {
                     $TemplateObject = $TemplateText | ConvertFrom-Json
                 } else {
-                    Write-Warning "Could not extract inner templates.  Please file an issue and attach your template."
+                    Write-Error "Could not extract inner templates for '$TemplatePath'." -ErrorId InnerTemplate.Extraction.Error
                 }
             }
             

--- a/arm-ttk/Expand-AzTemplate.ps1
+++ b/arm-ttk/Expand-AzTemplate.ps1
@@ -292,11 +292,13 @@ function Expand-AzTemplate
             
             $innerTemplates = @(if ($templateText -and $TemplateText.Contains('"template"')) {
                 Find-JsonContent -InputObject $templateObject -Key template |
-                    Where-Object { $_.expressionEvaluationOptions.scope -eq 'inner' -or $_.jsonPath -like '*.policyRule.*' }
+                    Where-Object { $_.expressionEvaluationOptions.scope -eq 'inner' -or $_.jsonPath -like '*.policyRule.*' } |
+                    Sort-Object JSONPath -Descending
             })
 
             if ($innerTemplates) {
                 $anyProblems = $false
+                $originalTemplateText = "$TemplateText"
                 foreach ($it in $innerTemplates) {
                     $foundInnerTemplate = $it | Resolve-JSONContent -JsonText $TemplateText
                     if (-not $foundInnerTemplate) { $anyProblems = $true; break }

--- a/arm-ttk/Expand-AzTemplate.ps1
+++ b/arm-ttk/Expand-AzTemplate.ps1
@@ -296,13 +296,19 @@ function Expand-AzTemplate
             })
 
             if ($innerTemplates) {
+                $anyProblems = $false
                 foreach ($it in $innerTemplates) {
                     $foundInnerTemplate = $it | Resolve-JSONContent -JsonText $TemplateText
+                    if (-not $foundInnerTemplate) { $anyProblems = $true; break }
                     $TemplateText = $TemplateText.Remove($foundInnerTemplate.Index, $foundInnerTemplate.Length)
                     $TemplateText = $TemplateText.Insert($foundInnerTemplate.Index, '"template": {}')
                 }
 
-                $TemplateObject = $TemplateText | ConvertFrom-Json
+                if (-not $anyProblems) {
+                    $TemplateObject = $TemplateText | ConvertFrom-Json
+                } else {
+                    Write-Warning "Could not extract inner templates.  Please file an issue and attach your template."
+                }
             }
             
             

--- a/arm-ttk/Resolve-JSONContent.ps1
+++ b/arm-ttk/Resolve-JSONContent.ps1
@@ -206,7 +206,7 @@
                 }
                 $cursor = $null
             } elseif ($part.Groups['Index'].Success) {
-                $targetIndex = $part.Groups['Index'].Value
+                $targetIndex = $part.Groups['Index'].Value -as [int]
                 $listMatch = $jsonList.Match($JSONText, $cursor)
                 $values = $listMatch.Groups["JSON_Value"].Captures
                 if ($targetIndex -gt $values.Count) {

--- a/arm-ttk/Resolve-JSONContent.ps1
+++ b/arm-ttk/Resolve-JSONContent.ps1
@@ -34,7 +34,7 @@
     [string]
     $JSONText
     )
-    begin {
+    begin {        
         $jsonProperty = [Regex]::new(@'
 (?<=             # After 
 [\{\,]           # a bracket or comma
@@ -65,20 +65,21 @@
         \{                        # An open brace
 (?>                               # Followed by...
     [^\{\}]+|                     # any number of non-brace character OR
-    \{(?<Depth>)|                 # an open brace (in which case increment depth) OR
-    \}(?<-Depth>)                 # a closed brace (in which case decrement depth)
-)*(?(Depth)(?!))                  # until depth is 0.
+    \{(?<BraceDepth>)|            # an open brace (in which case increment depth) OR
+    \}(?<-BraceDepth>)            # a closed brace (in which case decrement depth)
+)*(?(BraceDepth)(?!))             # until depth is 0.
 \}                                # followed by a closing brace
     )
     |                             # OR
     (?<List>                      # a list, which is
         \[                        # An open bracket
-(?>                               # Followed by...
-    [^\[\]]+|                     # any number of non-bracket character OR
-    \[(?<Depth>)|                 # an open bracket (in which case increment depth) OR
-    \](?<-Depth>)                 # a closed bracket (in which case decrement depth)
-)*(?(Depth)(?!))                  # until depth is 0.
-\]                                # followed by a closing bracket
+        (?>                       # Followed by...
+          (?<!\[)\[(?<Depth>) |   # an open single bracket (in which case increment depth) OR
+          \](?<-Depth>)       |   # a closed bracket (in which case decrement depth)    
+          [^\[\]]+            |   # any number of non-bracket character OR
+          (?<=\[)\[               # a double left bracket
+        )*(?(Depth)(?!))          # until depth is 0.
+        \]                        # followed by a closing bracket
     )
     |                             # OR
     (?<String>                    # A string, which is
@@ -106,7 +107,7 @@
 )
 \s{0,}                            # Optionally match following whitespace
 )
-'@, 'IgnoreCase,IgnorePatternWhitespace', '00:00:05')
+'@, 'Singleline,IgnoreCase,IgnorePatternWhitespace', '00:00:05')
 
         
         $jsonList = [Regex]::new(@'
@@ -136,12 +137,13 @@
     |                             # OR
     (?<List>                      # a list, which is
         \[                        # An open bracket
-(?>                               # Followed by...
-    [^\[\]]+|                     # any number of non-bracket character OR
-    \[(?<Depth>)|                 # an open bracket (in which case increment depth) OR
-    \](?<-Depth>)                 # a closed bracket (in which case decrement depth)
-)*(?(Depth)(?!))                  # until depth is 0.
-\]                                # followed by a closing bracket
+        (?>                       # Followed by...
+          (?<!\[)\[(?<Depth>) |   # an open single bracket (in which case increment depth) OR
+          \](?<-Depth>)       |   # a closed bracket (in which case decrement depth)    
+          [^\[\]]+            |   # any number of non-bracket character OR
+          (?<=\[)\[               # a double left bracket
+        )*(?(Depth)(?!))          # until depth is 0.
+        \]                        # followed by a closing bracket
     )
     |                             # OR
     (?<String>                    # A string, which is

--- a/unit-tests/_arm-ttk-module/InnerTemplate.module.tests.ps1
+++ b/unit-tests/_arm-ttk-module/InnerTemplate.module.tests.ps1
@@ -33,7 +33,7 @@ describe InnerTemplates {
     }
 
     it 'Will expand templates containing bracket escape sequences' {
-        $templatePath = $here | Join-Path -ChildPath InnerTemplatesWithEscapeSequence.json
+        $templatePath = $here | Join-Path -ChildPath InnerTemplateWithEscapeSequence.json
         $expanded = Expand-AzTemplate -TemplatePath $templatePath
         $expanded.innerTemplates.Count | Should -be 1
     }

--- a/unit-tests/_arm-ttk-module/InnerTemplate.module.tests.ps1
+++ b/unit-tests/_arm-ttk-module/InnerTemplate.module.tests.ps1
@@ -25,4 +25,16 @@ describe InnerTemplates {
             Select-Object -ExpandProperty Count |
             Should -Be 1
     }
+
+    it 'Will expand innermost templates first' {
+        $templatePath = $here | Join-Path -ChildPath NestedInnerTemplates.json
+        $expanded = Expand-AzTemplate -TemplatePath $templatePath
+        $expanded.innerTemplates.Count | Should -be 4
+    }
+
+    it 'Will expand templates containing bracket escape sequences' {
+        $templatePath = $here | Join-Path -ChildPath InnerTemplatesWithEscapeSequence.json
+        $expanded = Expand-AzTemplate -TemplatePath $templatePath
+        $expanded.innerTemplates.Count | Should -be 1
+    }
 }

--- a/unit-tests/_arm-ttk-module/InnerTemplateWithEscapeSequence.json
+++ b/unit-tests/_arm-ttk-module/InnerTemplateWithEscapeSequence.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "_artifactsLocation": {
+      "type": "string",
+      "defaultValue": "[substring(deployment().properties.templateLink.uri, 0, lastIndexOf(deployment().properties.templateLink.uri, '/'))]"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "defaultValue": ""
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[deployment().location]"
+    },
+    "diagnosticPolicies": {
+      "type": "array",
+      "defaultValue": [
+        "diagnostics-aa-deploy-policy",
+        "diagnostics-adf-deploy-policy",
+        "diagnostics-agw-deploy-policy"
+      ]
+    }
+  },
+  "resources": [
+    {
+      "name": "getManagementGroupName",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2021-01-01",
+      "location": "[parameters('location')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "Inner"
+        },
+        "mode": "Incremental",
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "resources": [ ]
+        }
+      }
+    },
+    {
+      "name": "[parameters('diagnosticPolicies')[copyIndex()]]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-08-01",
+      "location": "[parameters('location')]",
+      "properties": {
+        "mode": "Incremental",
+        "parameters": { },
+        "templateLink": {
+          "uri": "[format('{0}{1}.json{2}', parameters('_artifactsLocation'), parameters('diagnosticPolicies')[copyIndex()], parameters('_artifactsLocationSasToken'))]"
+        }
+      },
+      "copy": {
+        "name": "diagnosticPolicies",
+        "count": "[length(parameters('diagnosticPolicies'))]"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/policySetDefinitions",
+      "apiVersion": "2019-09-01",
+      "name": "diagnostics-loganalytics-deploy-initiative",
+      "dependsOn": [
+        "diagnosticPolicies"
+      ],
+      "properties": {
+        "displayName": "Deploy Diagnostics & Metrics for Azure Resource to a Log Analytics workspace",
+        "description": "Apply diagnostic & metric settings for Azure Resources to stream data to a Log Analytics workspace when any Azure Resource which is missing this diagnostic settings is created or updated.",
+        "policyType": "Custom",
+        "metadata": {
+          "category": "Monitoring",
+          "version": "1.0.0"
+        },
+        "parameters": {
+          "profileName": {
+            "type": "string",
+            "metadata": {
+              "displayName": "Profile name",
+              "description": "The diagnostic settings profile name"
+            },
+            "defaultValue": "setbypolicy_logAnalytics"
+          },
+          "logAnalytics": {
+            "type": "string",
+            "metadata": {
+              "displayName": "Log Analytics workspace",
+              "description": "Select Log Analytics workspace from dropdown list. If this workspace is outside of the scope of the assignment you must manually grant 'Log Analytics Contributor' permissions (or similar) to the policy assignment's principal ID.",
+              "strongType": "omsWorkspace",
+              "assignPermissions": true
+            }
+          }
+        },
+        "copy": [
+          {
+            "name": "policyDefinitions",
+            "count": "[length(parameters('diagnosticPolicies'))]",
+            "input": {
+              "policyDefinitionId": "[extensionResourceId(tenantResourceId('Microsoft.Management/managementGroups', split(reference('getManagementGroupName', '2020-10-01', 'Full').scope, '/')[2]), 'Microsoft.Authorization/policyDefinitions', parameters('diagnosticPolicies')[copyIndex('policyDefinitions')])]",
+              "policyDefinitionReferenceId": "[parameters('diagnosticPolicies')[copyIndex('policyDefinitions')]]",
+              "parameters": {
+                "profileName": {
+                  "value":  "[[[parameters('profileName')]"
+                },
+                "logAnalytics": {
+                  "value": "[[[parameters('logAnalytics')]"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/unit-tests/_arm-ttk-module/JSONC.module.tests.ps1
+++ b/unit-tests/_arm-ttk-module/JSONC.module.tests.ps1
@@ -1,8 +1,8 @@
 ﻿Push-Location $PSScriptRoot 
 
 describe "JSONC" {
-    it "Supports JSONC files" {
-        Test-AzTemplate -TemplatePath (Join-Path $pwd "Sample.jsonc") -Test 'DeploymentTemplate Schema Is Correct' |
+    it "Supports JSONC files" {        
+        Test-AzTemplate -TemplatePath (Join-Path $pwd "Sample.jsonc") -Test 'DeploymentTemplate Schema Is Correct' -File "Sample.jsonc"  |
             Select-Object -ExpandProperty Passed | 
             Should -Be $true
     }

--- a/unit-tests/_arm-ttk-module/JSONContentCommands.tests.ps1
+++ b/unit-tests/_arm-ttk-module/JSONContentCommands.tests.ps1
@@ -88,4 +88,17 @@ describe Resolve-JSONContent {
         $resolved.Line | Should -Be 4
         $resolved.Content | Should -Be "1"
     }
+
+    it 'Can resolve a JSON property with an ARM double-bracket escape sequence' {
+        $resolved = Resolve-JSONContent -JSONPath 'a[0].b.c' -JSONText @'
+{
+    "a": [{
+        'b': {
+            c: "[[0,1,2]"
+        }
+    }]
+}
+'@
+        $resolved.Line | Should -Be 4        
+    }
 }

--- a/unit-tests/_arm-ttk-module/NestedInnerTemplates.json
+++ b/unit-tests/_arm-ttk-module/NestedInnerTemplates.json
@@ -1,0 +1,342 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.451.19169",
+      "templateHash": "12209291292482475033"
+    }
+  },
+  "parameters": {
+    "enrollmentAccount": {
+      "type": "string",
+      "metadata": {
+        "description": "EnrollmentAccount used for subscription billing"
+      }
+    },
+    "billingAccount": {
+      "type": "string",
+      "metadata": {
+        "description": "BillingAccount used for subscription billing"
+      }
+    },
+    "subscriptionAlias": {
+      "type": "string",
+      "metadata": {
+        "description": "Alias to assign to the subscription"
+      }
+    },
+    "subscriptionDisplayName": {
+      "type": "string",
+      "metadata": {
+        "description": "Display name for the subscription"
+      }
+    },
+    "subscriptionWorkload": {
+      "type": "string",
+      "allowedValues": [
+        "Production",
+        "DevTest"
+      ],
+      "metadata": {
+        "description": "Workload type for the subscription"
+      }
+    },
+    "resourceGroupName": {
+      "type": "string",
+      "defaultValue": "demo",
+      "metadata": {
+        "description": "Name of the resourceGroup, will be created in the same location as the deployment."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[deployment().location]",
+      "metadata": {
+        "description": "Location for the deployments and the resources"
+      }
+    }
+  },
+  "functions": [],
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[format('create-{0}', parameters('subscriptionAlias'))]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "billingAccount": {
+            "value": "[parameters('billingAccount')]"
+          },
+          "enrollmentAccount": {
+            "value": "[parameters('enrollmentAccount')]"
+          },
+          "subscriptionAlias": {
+            "value": "[parameters('subscriptionAlias')]"
+          },
+          "subscriptionDisplayName": {
+            "value": "[parameters('subscriptionDisplayName')]"
+          },
+          "subscriptionWorkload": {
+            "value": "[parameters('subscriptionWorkload')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.451.19169",
+              "templateHash": "11044401809782387845"
+            }
+          },
+          "parameters": {
+            "enrollmentAccount": {
+              "type": "string",
+              "metadata": {
+                "description": "EnrollmentAccount used for subscription billing"
+              }
+            },
+            "billingAccount": {
+              "type": "string",
+              "metadata": {
+                "description": "BillingAccount used for subscription billing"
+              }
+            },
+            "subscriptionAlias": {
+              "type": "string",
+              "metadata": {
+                "description": "Alias to assign to the subscription"
+              }
+            },
+            "subscriptionDisplayName": {
+              "type": "string",
+              "metadata": {
+                "description": "Display name for the subscription"
+              }
+            },
+            "subscriptionWorkload": {
+              "type": "string",
+              "metadata": {
+                "description": "Workload type for the subscription"
+              }
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Subscription/aliases",
+              "apiVersion": "2020-09-01",
+              "scope": "/",
+              "name": "[parameters('subscriptionAlias')]",
+              "properties": {
+                "workload": "[parameters('subscriptionWorkload')]",
+                "displayName": "[parameters('subscriptionDisplayName')]",
+                "billingScope": "[tenantResourceId('Microsoft.Billing/billingAccounts/enrollmentAccounts', parameters('billingAccount'), parameters('enrollmentAccount'))]"
+              }
+            }
+          ],
+          "outputs": {
+            "subscriptionId": {
+              "type": "string",
+              "value": "[reference(tenantResourceId('Microsoft.Subscription/aliases', parameters('subscriptionAlias'))).subscriptionId]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "[format('nested-createResourceGroup-{0}', parameters('resourceGroupName'))]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "resourceGroupName": {
+            "value": "[parameters('resourceGroupName')]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "subscriptionId": {
+            "value": "[reference(format('Microsoft.Resources/deployments/{0}', format('create-{0}', parameters('subscriptionAlias'))), '2019-10-01').outputs.subscriptionId.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.451.19169",
+              "templateHash": "18387868050509077881"
+            }
+          },
+          "parameters": {
+            "subscriptionId": {
+              "type": "string",
+              "metadata": {
+                "description": "subscriptionId for the deployment"
+              }
+            },
+            "resourceGroupName": {
+              "type": "string",
+              "defaultValue": "demo",
+              "metadata": {
+                "description": "Name of the resourceGroup, will be created in the same location as the deployment."
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[deployment().location]",
+              "metadata": {
+                "description": "Location for the deployments and the resources"
+              }
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2019-10-01",
+              "name": "[format('create-{0}', parameters('resourceGroupName'))]",
+              "subscriptionId": "[parameters('subscriptionId')]",
+              "location": "[deployment().location]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "resourceGroupName": {
+                    "value": "[parameters('resourceGroupName')]"
+                  },
+                  "location": {
+                    "value": "[parameters('location')]"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.451.19169",
+                      "templateHash": "13810066068883746168"
+                    }
+                  },
+                  "parameters": {
+                    "resourceGroupName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Name of the resourceGroup."
+                      }
+                    },
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[deployment().location]"
+                    }
+                  },
+                  "functions": [],
+                  "resources": [
+                    {
+                      "type": "Microsoft.Resources/resourceGroups",
+                      "apiVersion": "2021-04-01",
+                      "name": "[parameters('resourceGroupName')]",
+                      "location": "[parameters('location')]"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2019-10-01",
+              "name": "[format('nested-createResourceGroup-{0}', format('create-{0}', parameters('resourceGroupName')))]",
+              "subscriptionId": "[parameters('subscriptionId')]",
+              "resourceGroup": "[format('create-{0}', parameters('resourceGroupName'))]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.4.451.19169",
+                      "templateHash": "16347142359648828745"
+                    }
+                  },
+                  "parameters": {
+                    "location": {
+                      "type": "string",
+                      "defaultValue": "[resourceGroup().location]"
+                    }
+                  },
+                  "functions": [],
+                  "variables": {
+                    "storageAccountName": "[format('stor{0}', uniqueString(resourceGroup().id))]"
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Storage/storageAccounts",
+                      "apiVersion": "2021-04-01",
+                      "name": "[variables('storageAccountName')]",
+                      "location": "[parameters('location')]",
+                      "kind": "StorageV2",
+                      "sku": {
+                        "name": "Standard_LRS"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "storageAccountId": {
+                      "type": "string",
+                      "value": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "[subscriptionResourceId(parameters('subscriptionId'), 'Microsoft.Resources/deployments', format('create-{0}', parameters('resourceGroupName')))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "storageAccountId": {
+              "type": "string",
+              "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('subscriptionId'), format('create-{0}', parameters('resourceGroupName'))), 'Microsoft.Resources/deployments', format('nested-createResourceGroup-{0}', format('create-{0}', parameters('resourceGroupName')))), '2019-10-01').outputs.storageAccountId.value]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[format('Microsoft.Resources/deployments/{0}', format('create-{0}', parameters('subscriptionAlias')))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "subscriptionId": {
+      "type": "string",
+      "value": "[reference(format('Microsoft.Resources/deployments/{0}', format('create-{0}', parameters('subscriptionAlias'))), '2019-10-01').outputs.subscriptionId.value]"
+    },
+    "storageAccountId": {
+      "type": "string",
+      "value": "[reference(format('Microsoft.Resources/deployments/{0}', format('nested-createResourceGroup-{0}', parameters('resourceGroupName'))), '2019-10-01').outputs.storageAccountId.value]"
+    }
+  }
+}


### PR DESCRIPTION
To avoid comparison issues.

This was causing the TargetIndex to be incorectly compared, which in turn caused Resolve-JSONContent to fail to find the match, which in turn caused the template to fail to snip at the right locations (and thus become corrupted)
