### PR TITLE
Expand-AzTemplate:  Switching variable expansion to use Write-Debug 

### DIFF
--- a/arm-ttk/Expand-AzTemplate.ps1
+++ b/arm-ttk/Expand-AzTemplate.ps1
@@ -348,7 +348,7 @@ function Expand-AzTemplate
 
                 if ($expandedTemplateText -ne $TemplateText) {
                     $expandedTemplateObject = try { $expandedTemplateText | ConvertFrom-Json -ErrorAction Stop -ErrorVariable err } catch {
-                        "$_" | Write-Verbose
+                        "$_" | Write-Debug
                     }
                 } else {
                     $expandedTemplateObject = $null


### PR DESCRIPTION
May Fix SuperLinter integration problem in #487 