### PR TITLE
Fixing #226 : Ignoring parent resources whose namespace is duplicated

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -106,7 +106,17 @@ foreach ($av in $allApiVersions) {
     }
 
     # To get the full type name, join them all with a slash
-    $FullResourceType = $FullResourceTypes -join '/'
+    $FullResourceType = @(for ($i = 0; $i -lt $FullResourceTypes.Length; $i++) {
+        # If it is not the last segment of a resource type
+        if ($i -lt ($FullResourceTypes.Length - 1)) {
+            # and it is is not included in a subsequent section
+            if (-not ($FullResourceTypes[($i+1)..$FullResourceTypes.Length] -match "^$($fullResourceTypes[$i])")) {
+                $fullResourceTypes[$i] # include it.
+            }            
+        } else {
+            $FullResourceTypes[$i] # Always include the last segment.
+        }       
+    }) -join '/'     
 
     # Now, get the API version as a string
     $apiString = $av.ApiVersion

--- a/unit-tests/apiversions-should-be-recent/Fail/apiVersion-duplicated-in-nested-resource.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/apiVersion-duplicated-in-nested-resource.json
@@ -11,6 +11,26 @@
                     "apiVersion": "2017-04-01"
                 }
             ]
+        },
+        {
+            "type": "Microsoft.ServiceBus/namespaces",
+            "apiVersion": "2018-01-01-preview",
+            "resources": [
+                {
+                    "type": "authorizationRules",
+                    "apiVersion": "2017-04-01"
+                }
+            ]
+        },
+        {
+            "type": "Microsoft.ServiceBus/namespaces",
+            "apiVersion": "2018-01-01-preview",
+            "resources": [
+                {
+                    "type": "queues/authorizationRules",
+                    "apiVersion": "2017-04-01"
+                }
+            ]
         }
     ]
 }

--- a/unit-tests/apiversions-should-be-recent/Fail/apiVersion-duplicated-in-nested-resource.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/apiVersion-duplicated-in-nested-resource.json
@@ -1,0 +1,18 @@
+﻿{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "resources": [
+        {
+            "type": "Microsoft.ServiceBus/namespaces",
+            "apiVersion": "2018-01-01-preview",
+            "resources": [
+                {
+                    "type": "Microsoft.ServiceBus/namespaces/queues/authorizationRules",
+                    "apiVersion": "2017-04-01"
+                }
+            ]
+        }
+    ]
+}
+
+


### PR DESCRIPTION
Ignoring parent resources whose namespace is duplicated in nested resources