### PR TITLE
On branch master: add inner template test case for Outputs-Must-Be-Present-In-Template-Parameters

### DIFF
--- a/arm-ttk/Test-AzTemplate.ps1
+++ b/arm-ttk/Test-AzTemplate.ps1
@@ -1,4 +1,4 @@
-﻿function Test-AzTemplate
+function Test-AzTemplate
 {
     [Alias('Test-AzureRMTemplate')] # Added for backward compat with MP
     <#
@@ -33,7 +33,6 @@ Each test script has access to a set of well-known variables:
 * InnerTemplates (indicates if the template contained or was in inner templates)
 * ExpandedTemplateText (the text of a template, with variables expanded)
 * ExpandedTemplateOjbect (the object of a template, with variables expanded)
-* InnerTemplates (indicates if the template contained or was in inner templates
 
     .Example
         Test-AzTemplate -TemplatePath ./FolderWithATemplate
@@ -265,6 +264,7 @@ Each test script has access to a set of well-known variables:
                         # And Map TemplateObject to the converted json (if the test command uses -TemplateObject)
                         if ($testCommandParameters.ContainsKey("TemplateObject")) { 
                             $templateObject = $testInput['TemplateObject'] = $innerTemplate.template
+                            $templateObject | Add-Member NoteProperty IsInnerTemplate $true -Force -PassThru
                             $usedParameters = $true
                         }
 

--- a/arm-ttk/testcases/CreateUIDefinition/Outputs-Must-Be-Present-In-Template-Parameters.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Outputs-Must-Be-Present-In-Template-Parameters.test.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .Synopsis
     Ensures that .outputs are present in the .parameters of CreateUIDefinition.json
 .Description
@@ -35,7 +35,13 @@ foreach ($output in $parameterInfo.outputs.psobject.properties) { # Then walk th
         $outputName -eq 'managedresourcegroupid') { # If the output was one of the outputs used for Managed Apps and only found in the generated template, skip the test
             continue 
     }
-    # If the output name was not declared in the TemplateObject,      
+
+    # If the TemplateObject is inner template of MainTemplate, skip the test
+    if ($TemplateObject.IsInnerTemplate){
+        continue
+    }
+    
+    # If the output name was not declared in the TemplateObject
     if (-not $TemplateObject.parameters.$outputName) {
         # write an error
         Write-Error "output $outputName does not exist in template.parameters" -ErrorId CreateUIDefinition.Output.Missing.From.MainTemplate -TargetObject $parameterInfo.outputs

--- a/unit-tests/Outputs-Must-Be-Present-In-Template-Parameters/Pass/InnerTemplate/azuredeploy.json
+++ b/unit-tests/Outputs-Must-Be-Present-In-Template-Parameters/Pass/InnerTemplate/azuredeploy.json
@@ -1,0 +1,71 @@
+{
+   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+   "contentVersion": "1.0.0.0",
+   "parameters": {
+      "location": {
+         "type": "string",
+         "defaultValue": "[resourceGroup().location]",
+         "metadata": {
+            "description": "Location for all resources."
+         }
+      },
+      "MyOutput": {
+         "type": "string",
+         "defaultValue": "test",
+         "metadata": {
+            "description": "Test output."
+         }
+      }
+   },
+   "variables": {
+   },
+   "resources": [
+      {
+         "type": "Microsoft.Resources/deployments",
+         "apiVersion": "2019-10-01",
+         "name": "initialization",
+         "properties": {
+            "expressionEvaluationOptions": {
+               "scope": "inner"
+            },
+            "mode": "Incremental",
+            "template": {
+               "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+               "contentVersion": "1.0.0.0",
+               "metadata": {
+                  "_generator": {
+                     "name": "bicep",
+                     "version": "0.4.451.19169",
+                     "templateHash": "10244511904155871293"
+                  }
+               },
+               "parameters": {
+                  "name": {
+                     "type": "string",
+                     "defaultValue": "pid"
+                  }
+               },
+               "functions": [],
+               "resources": [
+               ],
+               "outputs": {
+                  "name": {
+                     "type": "string",
+                     "value": "[parameters('name')]"
+                  }
+               }
+            }
+         }
+      }
+   ],
+   "outputs": {
+      "location": {
+         "type": "string",
+         "value": "[parameters('location')]"
+      },
+      "MyOutput": {
+         "type": "string",
+         "value": "[parameters('MyOutput')]"
+      }
+   }
+}

--- a/unit-tests/Outputs-Must-Be-Present-In-Template-Parameters/Pass/InnerTemplate/createUiDefinition.json
+++ b/unit-tests/Outputs-Must-Be-Present-In-Template-Parameters/Pass/InnerTemplate/createUiDefinition.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "TextBox1",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes With Invalid Regex",
+                "toolTip": "Textboxes with invalid regex.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^[1-9]$",
+                    "validationMessage": "Textboxes with invalid regex in constraints.regex."
+                }
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]",
+            "MyOutput": "foo"
+        }
+    }
+}


### PR DESCRIPTION
Error happens for `Outputs-Must-Be-Present-In-Template-Parameters` test case, when the main template has inner template, and the inner template does not have parameters the same from the UiDefinition outputs.  It's super common usage. Such case should pass.

Error message shows like:
```
 [-] Outputs Must Be Present In Template Parameters (6209 ms)
        output acrName does not exist in template.parameters
        output aksAgentPoolNodeCount does not exist in template.parameters
        output aksAgentPoolVMSize does not exist in template.parameters
        output aksClusterName does not exist in template.parameters
        output aksClusterRGName does not exist in template.parameters
```