### PR TITLE
Add inner template test case for APIVersion-Should-Be-Recent

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -86,18 +86,18 @@ foreach ($av in $allApiVersions) {
             # by walking backwards over the parent resources
             # (since the topmost resource will be the last item in the list)
             for ($i = $av.ParentObject.Count - 1; $i -ge 0; $i--) {
-                $parent=$av.ParentObject[$i]
+                $parent = $av.ParentObject[$i]
                 if (-not $parent.type) { continue }
 
-                # if parent resource type is Microsoft.Resources/deployments, and this is an inner template, skip
-                $expEvaOptions= $parent.properties.expressionEvaluationOptions
-                if ($parent.type -eq "Microsoft.Resources/deployments" -and $expEvaOptions) {
-                    $scope=$expEvaOptions.scope
+                # if parent resource type is Microsoft.Resources/deployments, and this is an inner template,
+                # do not add the prefix "Microsoft.Resources/deployments" to resource type.
+                $expEvalOptions = $parent.properties.expressionEvaluationOptions
+                if ($parent.type -eq "Microsoft.Resources/deployments" -and $expEvalOptions) {
+                    $scope = $expEvalOptions.scope
                     if ($scope -eq "inner") {
                         continue
                     }
                 }
-
                 $parent.type
             }
         }
@@ -128,8 +128,8 @@ foreach ($av in $allApiVersions) {
             }
             else {
                 $FullResourceTypes[$i] # Always include the last segment.
-            }       
-        }) -join '/'     
+            }
+        }) -join '/'
 
     # Now, get the API version as a string
     $apiString = $av.ApiVersion
@@ -142,8 +142,6 @@ foreach ($av in $allApiVersions) {
         continue # and move onto the next resource
     }
     $apiDate = [DateTime]::new($matches.Year, $matches.Month, $matches.Day) # now coerce the apiVersion into a DateTime
-
-
 
     # Now find all of the valid versions from this API
     $validApiVersions = # This is made a little tricky by the fact that some resources don't directly have an API version

--- a/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -86,8 +86,19 @@ foreach ($av in $allApiVersions) {
             # by walking backwards over the parent resources
             # (since the topmost resource will be the last item in the list)
             for ($i = $av.ParentObject.Count - 1; $i -ge 0; $i--) {
-                if (-not $av.ParentObject[$i].type) { continue }
-                $av.ParentObject[$i].type
+                $parent=$av.ParentObject[$i]
+                if (-not $parent.type) { continue }
+
+                # if parent resource type is Microsoft.Resources/deployments, and this is an inner template, skip
+                $expEvaOptions= $parent.properties.expressionEvaluationOptions
+                if ($parent.type -eq "Microsoft.Resources/deployments" -and $expEvaOptions) {
+                    $scope=$expEvaOptions.scope
+                    if ($scope -eq "inner") {
+                        continue
+                    }
+                }
+
+                $parent.type
             }
         }
         $av.type # and adding this resource's type.

--- a/unit-tests/apiversions-should-be-recent/Fail/OldApiVersion-In-Inner-Template.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/OldApiVersion-In-Inner-Template.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dnszoneName": {
+            "type": "string",
+            "defaultValue": "test.com",
+            "metadata": {
+                "description": "Test output."
+            }
+        }
+    },
+    "variables": {
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "name": "initialization",
+            "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                    "dnszoneName": {
+                        "value": "[parameters('dnszoneName')]"
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "metadata": {
+                        "_generator": {
+                            "name": "bicep",
+                            "version": "0.4.1008.15138",
+                            "templateHash": "6353609648537853708"
+                        }
+                    },
+                    "parameters": {
+                        "dnszoneName": {
+                            "type": "string",
+                            "metadata": {
+                                "description": "Azure DNS Zone name."
+                            }
+                        }
+                    },
+                    "functions": [],
+                    "resources": [
+                        {
+                            "type": "Microsoft.Network/dnsZones",
+                            "apiVersion": "2016-04-01",
+                            "name": "[parameters('dnszoneName')]",
+                            "location": "global",
+                            "properties": {
+                                "zoneType": "Public"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/unit-tests/apiversions-should-be-recent/Pass/Api-In-Inner-Template.json
+++ b/unit-tests/apiversions-should-be-recent/Pass/Api-In-Inner-Template.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "dnszoneName": {
+            "type": "string",
+            "defaultValue": "test.com",
+            "metadata": {
+                "description": "Test output."
+            }
+        }
+    },
+    "variables": {
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2019-10-01",
+            "name": "initialization",
+            "properties": {
+                "expressionEvaluationOptions": {
+                    "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                    "dnszoneName": {
+                        "value": "[parameters('dnszoneName')]"
+                    }
+                },
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "metadata": {
+                        "_generator": {
+                            "name": "bicep",
+                            "version": "0.4.1008.15138",
+                            "templateHash": "6353609648537853708"
+                        }
+                    },
+                    "parameters": {
+                        "dnszoneName": {
+                            "type": "string",
+                            "metadata": {
+                                "description": "Azure DNS Zone name."
+                            }
+                        }
+                    },
+                    "functions": [],
+                    "resources": [
+                        {
+                            "type": "Microsoft.Network/dnsZones",
+                            "apiVersion": "2018-05-01",
+                            "name": "[parameters('dnszoneName')]",
+                            "location": "global",
+                            "properties": {
+                                "zoneType": "Public"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}


### PR DESCRIPTION
Calling an API in the inner template, test case `apiVersions-Should-Be-Recent` constructs the resource type by adding prefix "Microsoft.Resources/deployments", then getting resource type like "Microsoft.Resources/deployments/Microsoft.Network/dnsZones", which causes the test failed. This case should pass.

Error example:

```text
[-] apiVersions Should Be Recent (5359 ms)
        The apiVersion 2020-07-01 was not found for the resource type: M
icrosoft.Resources/deployments/Microsoft.Network/networkSecurityGroups
        The apiVersion 2020-07-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.Network/virtualNetworks
        The apiVersion 2020-07-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.Network/publicIPAddresses
        The apiVersion 2020-07-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.Network/applicationGateways
        Api versions must be the latest or under 2 years old (730 da
ys) - API version 2018-05-01 of Microsoft.Resources/deployments/Microsoft.Netwo
rk/dnsZones is 1290 days old
        Valid Api Versions:
        2021-01-01
        2021-01-01
        2020-10-01
        2020-06-01
        The apiVersion 2021-06-01-preview was not found for the resource
 type: Microsoft.Resources/deployments/Microsoft.KeyVault/vaults
        The apiVersion 2021-06-01-preview was not found for the reso
urce type: Microsoft.Resources/deployments/Microsoft.KeyVault/vaults
        The apiVersion 2021-06-01-preview was not found for the reso
urce type: Microsoft.Resources/deployments/Microsoft.KeyVault/vaults/secrets
        The apiVersion 2021-06-01-preview was not found for the reso
urce type: Microsoft.Resources/deployments/Microsoft.KeyVault/vaults/secrets
        The apiVersion 2021-06-01-preview was not found for the reso
urce type: Microsoft.Resources/deployments/Microsoft.KeyVault/vaults
        The apiVersion 2021-06-01-preview was not found for the reso
urce type: Microsoft.Resources/deployments/Microsoft.KeyVault/vaults/secrets
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Storage/storageAccounts/fileServices/shares
        The apiVersion 2020-08-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.OperationalInsights/workspaces
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.ContainerService/managedClusters
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.ContainerService/managedClusters
        The apiVersion 2020-11-01-preview was not found for the reso
urce type: Microsoft.Resources/deployments/Microsoft.ContainerRegistry/registri
es
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.Storage/storageAccounts
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.Storage/storageAccounts/fileServic
es/shares
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Storage/storageAccounts/fileServices/shares
        The apiVersion 2020-08-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.OperationalInsights/workspaces
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.ContainerService/managedClusters
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.ContainerService/managedClusters
        The apiVersion 2020-11-01-preview was not found for the reso
urce type: Microsoft.Resources/deployments/Microsoft.ContainerRegistry/registri
es
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.Storage/storageAccounts
        The apiVersion 2021-02-01 was not found for the resource typ
e: Microsoft.Resources/deployments/Microsoft.Storage/storageAccounts/fileServic
es/shares
```