### PR TITLE
Adding additional tests to validate passwordbox length

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/PasswordBoxes-Must-Have-Min-Length.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/PasswordBoxes-Must-Have-Min-Length.test.ps1
@@ -36,7 +36,7 @@ foreach ($pwb in $passwordBoxes) { # Loop over each password box
     }
 
     try { # If it did,
-        $constraintWasRegex = [Regex]::new($textbox.constraints.regex) # try to cast to a regex
+        $constraintWasRegex = [Regex]::new($pwb.constraints.regex) # try to cast to a regex
         $hasLengthConstraint = $lengthConstraintRegex.Matches($pwb.constraints.regex)
 
         if (-not $hasLengthConstraint) {

--- a/unit-tests/PasswordBoxes-Must-Have-Min-Length/Pass/Has-Complex-Constraint.json
+++ b/unit-tests/PasswordBoxes-Must-Have-Min-Length/Pass/Has-Complex-Constraint.json
@@ -1,0 +1,26 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+  "handler": "Microsoft.Compute.MultiVm",
+  "version": "0.1.2-preview",
+  "parameters": {
+    "basics": [
+      {
+        "name": "adminPassword",
+        "type": "Microsoft.Common.PasswordBox",
+        "label": {
+          "password": "password",
+          "confirmPassword": "Confirm password"
+        },
+        "constraints": {
+          "required": true,
+          "regex": "(?=.{12,})((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])|(?=.*\\d)(?=.*[a-zA-Z])(?=.*[\\W_])|(?=.*[a-z])(?=.*[A-Z])(?=.*[\\W_])).*",
+          "validationMessage": "Password must be at least 12 characters long"
+        },
+        "options": {
+          "hideConfirmation": false
+        }
+      }
+    ],
+    "steps": []
+  }
+}

--- a/unit-tests/PasswordBoxes-Must-Have-Min-Length/Pass/Has-Complex-Constraint2.json
+++ b/unit-tests/PasswordBoxes-Must-Have-Min-Length/Pass/Has-Complex-Constraint2.json
@@ -1,0 +1,26 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+  "handler": "Microsoft.Compute.MultiVm",
+  "version": "0.1.2-preview",
+  "parameters": {
+    "basics": [
+      {
+        "name": "adminPassword",
+        "type": "Microsoft.Common.PasswordBox",
+        "label": {
+          "password": "password",
+          "confirmPassword": "Confirm password"
+        },
+        "constraints": {
+          "required": true,
+          "regex": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}$",
+          "validationMessage": "Password must be at least 12 characters long"
+        },
+        "options": {
+          "hideConfirmation": false
+        }
+      }
+    ],
+    "steps": []
+  }
+}


### PR DESCRIPTION
Adding additional tests to validate passwordbox length (re: #187)
Also, fixing a typo