### PR TITLE
On branch master: Fix error condition in Test.AzTemplate.sh and TestAzTemplate.cmd

### DIFF
--- a/arm-ttk/Test-AzTemplate.cmd
+++ b/arm-ttk/Test-AzTemplate.cmd
@@ -1,1 +1,1 @@
-powershell.exe -noprofile -nologo -command "Import-Module '%~dp0arm-ttk.psd1'; Test-AzTemplate %*; if ($error.Count) { exit 1}"
+powershell.exe -noprofile -nologo -command "Import-Module '%~dp0arm-ttk.psd1'; Test-AzTemplate %*; if ($Errors.Count) { exit 1}"

--- a/arm-ttk/Test-AzTemplate.sh
+++ b/arm-ttk/Test-AzTemplate.sh
@@ -8,4 +8,4 @@ case "${unameOut}" in
     Darwin*)    LOCAL_READLINK=greadlink;;
 esac
 
-pwsh -noprofile -nologo -command "Import-Module '$(dirname $(${LOCAL_READLINK} -f $0))/arm-ttk.psd1'; Test-AzTemplate $@ ; if (\$error.Count) { exit 1}"
+pwsh -noprofile -nologo -command "Import-Module '$(dirname $(${LOCAL_READLINK} -f $0))/arm-ttk.psd1'; Test-AzTemplate $@ ; if (\$Errors.Count) { exit 1}"


### PR DESCRIPTION
I got all the test case passed, but the process exit with 1. And I found in Test-AzTemplate.sh `error.Count` is not equals to `Errors.Count`. We should use `Errors.Count` as it is defined in [Test-AzTemplate.ps1 line 392](https://github.com/Azure/arm-ttk/blob/d208d8bc8e5a12b04f69239881c0e4e460b9ed15/arm-ttk/Test-AzTemplate.ps1#L392)

I logged the difference:
```text
bamboo@cn-haiche-0107:/mnt/c/Users/haiche/Documents/wlsonaks/arm-ttk/arm-ttk$ sh Test-AzTemplate.sh -TemplatePath /mytemplates/arm
                                                                                                                                                                                                                  Validating arm\deletenodedeploy.parameters.json
  deploymentParameters                                                                                                                                                                                                [+] DeploymentParameters Should Have ContentVersion (31 ms)                                                                                                                                                       [+] DeploymentParameters Should Have Parameters (15 ms)                                                                                                                                                           [+] DeploymentParameters Should Have Schema (17 ms)                                                                                                                                                               [+] DeploymentParameters Should Have Value (23 ms)                                                                                                                                                            Validating arm\mainTemplate.json                                                                                                                                                                                    deploymentTemplate                                                                                                                                                                                                  [+] adminUsername Should Not Be A Literal (42 ms)
[+] apiVersions Should Be Recent In Reference Functions (30 ms)                                                                                                                                                   [+] apiVersions Should Be Recent (71 ms)
[+] artifacts parameter (19 ms)                                                                                                                                                                                   [+] CommandToExecute Must Use ProtectedSettings For Secrets (73 ms)
[+] DependsOn Best Practices (31 ms)
[+] Deployment Resources Must Not Be Debug (29 ms)
[+] DeploymentTemplate Must Not Contain Hardcoded Uri (25 ms)
[+] DeploymentTemplate Schema Is Correct (14 ms)                                                                                                                                                                  [+] Dynamic Variable References Should Not Use Concat (16 ms)
[+] IDs Should Be Derived From ResourceIDs (36 ms)
[+] Location Should Not Be Hardcoded (37 ms)
[+] ManagedIdentityExtension must not be used (21 ms)
[+] Min And Max Value Are Numbers (20 ms)
[+] Outputs Must Not Contain Secrets (24 ms)
[+] Parameters Must Be Referenced (51 ms)
[+] Password params must be secure (19 ms)
[+] providers apiVersions Is Not Permitted (16 ms)
[+] ResourceIds should not contain (21 ms)
[+] Resources Should Have Location (18 ms)                                                                                                                                                                        [+] Resources Should Not Be Ambiguous (27 ms)
[+] Secure Params In Nested Deployments (36 ms)                                                                                                                                                                   [+] Secure String Parameters Cannot Have Default (16 ms)                                                                                                                                                          [+] Template Should Not Contain Blanks (20 ms)
[+] Variables Must Be Referenced (25 ms)                                                                                                                                                                          [+] Virtual Machines Should Not Be Preview (54 ms)
[+] VM Images Should Use Latest Version (15 ms)                                                                                                                                                                   [+] VM Size Should Be A Parameter (34 ms)
Pass  : 32
Total : 32
Fail  : 0
                                                                                                                                                                                                                                                                                                                                                                                                                                    
Errors.Count:
0
error.Count:
1
bamboo@cn-haiche-0107:/mnt/c/Users/haiche/Documents/wlsonaks/arm-ttk/arm-ttk$ echo $?
1
bamboo@cn-haiche-0107:/mnt/c/Users/haiche/Documents/wlsonaks/arm-ttk/arm-ttk$
```

This may be a regression, I used commit `d97aa57d259e2fc8562e11501b1cf902265129d9`, the shell script exits normally.

Template caused the failure: https://github.com/galiacheng/weblogic-azure/blob/test/weblogic-azure-vm/arm-oraclelinux-wls-cluster/deletenode/src/main/arm/mainTemplate.json