### PR TITLE
Fixing typo paramSection > paramsSection (location issue)

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Location-Should-Not-Be-Hardcoded.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Location-Should-Not-Be-Hardcoded.test.ps1
@@ -45,7 +45,7 @@ $deployments    = Find-JsonContent -InputObject $TemplateObject -Key type -Value
 
 $ignoredRanges = 
     @() + @(
-        if ($paramsSection.Index -and $paramSection.Length) {
+        if ($paramsSection.Index -and $paramsSection.Length) {
             $paramsSection.Index..($paramsSection.Index + $paramsSection.Length)
         }
     ) + @(


### PR DESCRIPTION
Fixed typo in the location test file

mentioned here: https://github.com/Azure/arm-ttk/issues/610