### PR TITLE
improved error message for vm size failure

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/VM-Size-Should-Be-A-Parameter.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/VM-Size-Should-Be-A-Parameter.test.ps1
@@ -5,9 +5,9 @@
     Ensures that the Sizes of a virtual machine in a template are parameters
 #>
 param(
-[Parameter(Mandatory=$true)]
-[PSObject]
-$TemplateObject
+    [Parameter(Mandatory = $true)]
+    [PSObject]
+    $TemplateObject
 )
 
 $vmSizes = $TemplateObject.resources | Find-JsonContent -Key vmSize -Value * -Like
@@ -15,15 +15,19 @@ $vmSizes = $TemplateObject.resources | Find-JsonContent -Key vmSize -Value * -Li
 foreach ($vmSizeObject in $vmSizes) {
     
     $vmSize = $vmSizeObject.vmSize
+    $resourceType = $vmSizeObject.ParentObject.type
+    $resourceName = $vmSizeObject.ParentObject.name
 
     if ($vmSize -notmatch "\s{0,}\[.*?parameters\s{0,}\(\s{0,}'") {
         if ($vmSize -match "\s{0,}\[.*?variables\s{0,}\(\s{0,}'") {
             $resolvedVmSize = Expand-AzTemplate -Expression $vmSize -InputObject $TemplateObject
             if ($resolvedVmSize -notmatch "\s{0,}\[.*?parameters\s{0,}\(\s{0,}'") {
-                Write-Error "VM Size must be a parameter" -TargetObject $vm
+                Write-Error "VM Size for resourceType '$resourceType' named '$resourceName' must be a parameter" -TargetObject $vm
             }
-        } else {
-            Write-Error "VM Size must be a parameter" -TargetObject $vm
+        }
+        else {
+            Write-Error "VM Size for resourceType '$resourceType' named '$resourceName' must be a parameter" -TargetObject $vm
         }
     }
+
 }

--- a/unit-tests/VM-Size-Should-Be-A-Parameter/Fail/nested-param.json
+++ b/unit-tests/VM-Size-Should-Be-A-Parameter/Fail/nested-param.json
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "_artifactsLocation": {
+      "type": "string"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring"
+    }
+  },
+  "variables": {
+    "vmTemplateLink": "[concat(parameters('_artifactsLocation'),'common/vm.json', parameters('_artifactsLocationSasToken'))]"
+  },
+  "resources": [
+    {
+      "name": "Deploy_VM",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('vmTemplateLink')]"
+        },
+        "parameters": {
+          "vmSize": {
+            "value": "Standard_D2_v3"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/unit-tests/VM-Size-Should-Be-A-Parameter/Pass/azuredeploy.json
+++ b/unit-tests/VM-Size-Should-Be-A-Parameter/Pass/azuredeploy.json
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmSize": {
+      "type": "object"
+    },
+    "_artifactsLocation": {
+      "type": "string"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring"
+    }
+  },
+  "variables": {
+    "vmTemplateLink": "[concat(parameters('_artifactsLocation'),'common/vm.json', parameters('_artifactsLocationSasToken'))]"
+  },
+  "resources": [
+    {
+      "name": "[concat('Deploy_VM', copyIndex())]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('vmTemplateLink')]"
+        },
+        "parameters": {
+          "vmSize": {
+            "value": "[parameters('vmSize')]"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
since we just check for any property named "vmSize" anywhere in the template, adding some info to the error message about which resource contains the error.