### PR TITLE
Add "schemaId" as exception property for IDs-Should-Be-Derived-From-ResourceIDs test

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -68,7 +68,8 @@ foreach ($id in $ids) {
         "connectorId",                 # Microsoft.Sentinel/Solutions/Analytical Rule/Metadata
         "parentId",                    # Microsoft.Sentinel/Solutions/Metadata
         "IllusiveIncidentId",          # Microsoft.Sentinel/Solutions/Analytical Rule/Metadata
-        "UniqueFindingId"              # Microsoft.Sentinel/Solutions/Metadata
+        "UniqueFindingId",             # Microsoft.Sentinel/Solutions/Metadata
+        "schemaId"                     # Microsoft.ApiManagement/service/apis/operations
     )
 
     $exceptionRegex =


### PR DESCRIPTION
According the Microsoft Support Engineer Tolani Odumosu, the "schemaId" property expects to receive the schema identifier value only, and not a resourceId. So, this exception rule allow to successfully pass IDs-Should-Be-Derived-From-ResourceIDs test