### PR TITLE
Fix Typo

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/Parameters-Without-Default-Must-Exist-In-CreateUIDefinition.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Parameters-Without-Default-Must-Exist-In-CreateUIDefinition.test.ps1
@@ -1,8 +1,8 @@
 ﻿<#
 .Synopsis
-    Ensure that parameters that don't have defaultValues are defined CreateUIDefinition.outuputs
+    Ensure that parameters that don't have defaultValues are defined CreateUIDefinition.outputs
 .Description
-    Ensure that parameters that don't have defaultValues are defined CreateUIDefinition.outuputs
+    Ensure that parameters that don't have defaultValues are defined CreateUIDefinition.outputs
 #>
 
 param(


### PR DESCRIPTION
Fixing type in `outputs`

<img width="622" alt="image" src="https://user-images.githubusercontent.com/9027725/184260536-eef9e940-e37a-4004-9ebb-aa8b3615a2f3.png">
