### PR TITLE
Fix issue with latest api version being older than 2 years

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -234,7 +234,7 @@ foreach ($av in $allApiVersions) {
             $trimmedApiVersion = $validApiVersions[0].ToString().Substring(0, $validApiVersions[0].ToString().LastIndexOf("-"))
             $nonPreviewVersionInUse = ($trimmedApiVersion -eq $av.apiVersion)
         }
-        if (-not $nonPreviewVersionInUse) {            
+        if ($nonPreviewVersionInUse) {            
             if ($($av.ApiVersion) -eq $latestStableApiVersion) {     
                 #break from loop to avoid throwing error when using latest stable API version           
                 break


### PR DESCRIPTION
Remove ```-not``` which seems to require that the api version be a preview version, if the latest version is older than 2 years old, which I believe to be the opposite of the intention.