### PR TITLE
added exception for old bicep version

### DIFF
--- a/unit-tests/apiversions-should-be-recent/Fail/not-bicep-module.json
+++ b/unit-tests/apiversions-should-be-recent/Fail/not-bicep-module.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+      "_generator": {
+        "name": "not-bicep"
+      }
+    },
+    "parameters": { },
+    "resources": [
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2015-01-01",
+        "name": "nested",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": { },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "metadata": {
+              "_generator": {
+                "name": "bicep",
+                "version": "0.5.6.12127",
+                "templateHash": "6034226420560042393"
+              }
+            },
+            "resources": [ ]
+          }
+        }
+      }
+    ]
+  }

--- a/unit-tests/apiversions-should-be-recent/Pass/bicep-module.json
+++ b/unit-tests/apiversions-should-be-recent/Pass/bicep-module.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "metadata": {
+      "_generator": {
+        "name": "bicep",
+        "version": "0.5.6.12127",
+        "templateHash": "16815708176905569328"
+      }
+    },
+    "parameters": { },
+    "resources": [
+      {
+        "type": "Microsoft.Resources/deployments",
+        "apiVersion": "2015-01-01",
+        "name": "nested",
+        "properties": {
+          "expressionEvaluationOptions": {
+            "scope": "inner"
+          },
+          "mode": "Incremental",
+          "parameters": { },
+          "template": {
+            "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "metadata": {
+              "_generator": {
+                "name": "bicep",
+                "version": "0.5.6.12127",
+                "templateHash": "6034226420560042393"
+              }
+            },
+            "resources": [ ]
+          }
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
bicep modules generate an old apiVersion and the user cannot change it - adding an exception for /deployments resources when bicep is detected.