### PR TITLE
Fix missing space when generating Warning if password minimum length is failing.

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/PasswordBoxes-Must-Have-Min-Length.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/PasswordBoxes-Must-Have-Min-Length.test.ps1
@@ -47,7 +47,7 @@ foreach ($pwb in $passwordBoxes) { # Loop over each password box
                 $totalMins += $match.Groups['Min'].Value -as [int]
             }
             if ($passWordMinLength -gt $totalMins) {
-                Write-Warning"PasswordBox '$($pwb.Name)' regex does not have a minimum length of $PasswordMinLength" -TargetObject $pwb
+                Write-Warning "PasswordBox '$($pwb.Name)' regex does not have a minimum length of $PasswordMinLength" -TargetObject $pwb
             }
         }
     } catch {


### PR DESCRIPTION
Fix missing space when generating Warning if password minimum length is failing.
