### PR TITLE
Extend CreateUI Test Coverage

### DIFF
--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
@@ -14,6 +14,17 @@
                     "regex": "^[0-9]{5,10}$",
                     "validationMessage": "Textboxes with constraints.regex contains length limits."
                 }
+            },
+            {
+                "name": "TextBox2",
+                "type": "Microsoft.Common.TextBox",
+                "label": "Textboxes-With-Constrains-Validations",
+                "toolTip": "Textboxes with constraints.validations.",
+                "constraints": {
+                    "required": true,
+                    "regex": "^[0-9][0-9-]{5,9}[0-9]$",
+                    "validationMessage": "Textboxes with constraints.regex contains length limits."
+                }
             }
         ],
         "outputs": {

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
@@ -18,11 +18,10 @@
             {
                 "name": "TextBox2",
                 "type": "Microsoft.Common.TextBox",
-                "label": "Textboxes-With-Constrains-Validations",
+                "label": "Textboxes-With-Constrains-Validations-2",
                 "toolTip": "Textboxes with constraints.validations.",
                 "constraints": {
-                    "required": true,
-                    "regex": "^[0-9][0-9-]{5,9}[0-9]$",
+                    "regex": "^[A-Za-z][A-Za-z0-9-]{1,61}[A-Za-z0-9]$",
                     "validationMessage": "Textboxes with constraints.regex contains length limits."
                 }
             }


### PR DESCRIPTION
Textboxes-With-Length-Constrains-Regex should not fail when length constraint is in the middle.

<img width="560" alt="image" src="https://user-images.githubusercontent.com/9027725/205691720-ba248ded-e1e8-4593-bcc7-c19bddc22995.png">


```json
          {
            "name": "issuerProvider",
            "type": "Microsoft.Common.TextBox",
            "label": "Custom Issuer Provider",
            "toolTip": "certificate Issuer Provider",
            "visible": "[equals(steps('Security').issuerProviderDropDown, 'Custom')]",
            "defaultValue": "",
            "constraints": {
              "validations": [
                {
                  "regex": "^[A-Za-z][A-Za-z0-9-]{1,61}[A-Za-z0-9]$",
                  "message": "The certificate issuer can only contain alphanumeric values, and hyphens, but may not end with a hyphen."
                }
              ]
            }          
          }
```
