### PR TITLE
Updated Regex used by Textbox Length Check Test

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1
@@ -13,8 +13,8 @@ param(
 
 # First, find all textboxes within CreateUIDefinition.
 $allTextBoxes = $CreateUiDefinitionObject | Find-JsonContent -Key type -value Microsoft.Common.TextBox
-# Regex Constraint should contain the pattern {m,n} or {m,} or {m} (Length Check)
-$lengthContraintRegex = [Regex]::new('{\d+(?:,\d+|,)?}')
+# Regex Constraint should contain one of following pattern (Length Check): {m,n} or {m,} or {m}
+$lengthContraintRegex = [Regex]::new('\{(?<Min>\d+)(?:,(?<Max>\d+)|,)?\}')
 
 foreach ($textbox in $allTextBoxes) {
     # Then we walk over each textbox.

--- a/arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Textboxes-Are-Well-Formed.test.ps1
@@ -12,12 +12,9 @@ param(
 )
 
 # First, find all textboxes within CreateUIDefinition.
-
 $allTextBoxes = $CreateUiDefinitionObject | Find-JsonContent -Key type -value Microsoft.Common.TextBox
-# Match length constraint at beginning of regex.
-# Input string starts with ^(?=.{N,N}                ^   (   ?  =   .  {N          ,N}
-$lengthConstraintRegexAtBeginning = [Regex]::new('^[\^][\(][\?][=][\.]\{(?<Min>\d+),(?<Max>\d+)?\}.*')
-$lengthConstraintRegexAtEnd = [Regex]::new('\{(?<Min>\d+),(?<Max>\d+)?\}(\$)?$')
+# Regex Constraint should contain the pattern {m,n} or {m,} or {m} (Length Check)
+$lengthContraintRegex = [Regex]::new('{\d+(?:,\d+|,)?}')
 
 foreach ($textbox in $allTextBoxes) {
     # Then we walk over each textbox.
@@ -26,6 +23,7 @@ foreach ($textbox in $allTextBoxes) {
         Write-Error -Message "Textbox $($textbox.Name) is missing constraints" -ErrorId Textboxes.Are.Well.Formed.Missing.Constraints -TargetObject $textbox # error
         continue # and continue (since additional failures would be noise).
     }
+
     $constraintRegexString = "";
     if ($textbox.constraints.validations) {
         $constraintRegexString = foreach ($validation in $textbox.constraints.validations) {
@@ -37,27 +35,27 @@ foreach ($textbox in $allTextBoxes) {
     elseif ($textbox.constraints.regex) {
         $constraintRegexString = $textbox.constraints.regex
         if (-not $textbox.constraints.validationMessage) {
-            # If there's not a validation message
+            # Regex constraint is missing validation message
             Write-Error -Message "Textbox $($textbox.Name) is missing constraints.validationMessage" -ErrorId Textboxes.Are.Well.Formed.Missing.Constraints.ValidationMessage -TargetObject $textbox #error.
         }
     }
+
     if (-not $constraintRegexString ) {
-        # If the constraint didn't have a regex,
+        # If the constraint didn't have a regex
         Write-Error -Message "Textbox $($textbox.Name) is missing constraints.regex or regex property in constraints.validations" -ErrorId Textboxes.Are.Well.Formed.Missing.Constraints.Regex -TargetObject $textbox #error.
     }
     else {
         try {
-            # If it did,
+            # If it did
             $constraintWasRegex = [Regex]::new($constraintRegexString) # try to cast to a regex
-            $hasLengthConstraintAtBeginning = $lengthConstraintRegexAtBeginning.Match($constraintRegexString)
-            $hasLengthConstraintAtEnd = $lengthConstraintRegexAtEnd.Match($constraintRegexString)
+            $hasLengthConstraint = $lengthContraintRegex.Match($constraintRegexString)
     
-            if (-not ($hasLengthConstraintAtBeginning.Success -or $hasLengthConstraintAtEnd.Success -or $isExpression.Success)) {
+            if (-not ($hasLengthConstraint.Success)) {
                 Write-Warning "TextBox '$($textBox.Name)' regex does not have a length constraint." 
             }
         }
         catch {
-            $err = $_ # if that fails, 
+            $err = $_ # if that fails
             Write-Error -Message "Textbox $($textbox.Name) regex is invalid: $($err)" -ErrorId Textboxes.Are.Well.Formed.Invalid.Constraints.Regex.Expressison -TargetObject $textbox #error.
         }
     }

--- a/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
+++ b/unit-tests/Textboxes-Are-Well-Formed/Pass/Textboxes-With-Length-Constrains-Regex/createUiDefinition.json
@@ -1,33 +1,63 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
-    "handler": "Microsoft.Azure.CreateUIDef",
-    "version": "0.1.2-preview",
-    "parameters": {
-        "basics": [
-            {
-                "name": "TextBox1",
-                "type": "Microsoft.Common.TextBox",
-                "label": "Textboxes-With-Constrains-Validations",
-                "toolTip": "Textboxes with constraints.validations.",
-                "constraints": {
-                    "required": true,
-                    "regex": "^[0-9]{5,10}$",
-                    "validationMessage": "Textboxes with constraints.regex contains length limits."
-                }
-            },
-            {
-                "name": "TextBox2",
-                "type": "Microsoft.Common.TextBox",
-                "label": "Textboxes-With-Constrains-Validations-2",
-                "toolTip": "Textboxes with constraints.validations.",
-                "constraints": {
-                    "regex": "^[A-Za-z][A-Za-z0-9-]{1,61}[A-Za-z0-9]$",
-                    "validationMessage": "Textboxes with constraints.regex contains length limits."
-                }
-            }
-        ],
-        "outputs": {
-            "Location": "[location()]"
-        }
-    }
+	"$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+	"handler": "Microsoft.Azure.CreateUIDef",
+	"version": "0.1.2-preview",
+	"parameters": {
+		"basics": [
+			{
+				"name": "TextBox1",
+				"type": "Microsoft.Common.TextBox",
+				"label": "Textboxes-With-Constrains-Validations",
+				"toolTip": "Textboxes with constraints.validations.",
+				"constraints": {
+					"required": true,
+					"regex": "^[0-9]{5,10}$",
+					"validationMessage": "Textboxes with constraints.regex contains length limits."
+				}
+			},
+			{
+				"name": "TextBox2",
+				"type": "Microsoft.Common.TextBox",
+				"label": "Textboxes-With-Constrains-Validations-2",
+				"toolTip": "Textboxes with constraints.validations.",
+				"constraints": {
+					"regex": "^[A-Za-z][A-Za-z0-9-]{1,61}[A-Za-z0-9]$",
+					"validationMessage": "Textboxes with constraints.regex contains length limits."
+				}
+			},
+			{
+				"name": "TextBox3",
+				"type": "Microsoft.Common.TextBox",
+				"label": "Textboxes-With-Constrains-Validations-3",
+				"toolTip": "Textboxes with constraints.validations.",
+				"constraints": {
+					"regex": "^(?!-)[A-Za-z0-9-]{3,63}(?<!-)$",
+					"validationMessage": "Textboxes with constraints.regex contains length limits."
+				}
+			},
+			{
+				"name": "TextBox4",
+				"type": "Microsoft.Common.TextBox",
+				"label": "Textboxes-With-Constrains-Validations-4",
+				"toolTip": "Textboxes with constraints.validations.",
+				"constraints": {
+					"regex": "^[0-9a-fA-F]{8}-(?:[0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$",
+					"validationMessage": "Textboxes with constraints.regex contains length limits."
+				}
+			},
+			{
+				"name": "TextBox5",
+				"type": "Microsoft.Common.TextBox",
+				"label": "Textboxes-With-Constrains-Validations-5",
+				"toolTip": "Textboxes with constraints.validations.",
+				"constraints": {
+					"regex": "^[A-Za-z0-9-+/@$!%*?&]{12,}$",
+					"validationMessage": "Textboxes with constraints.regex contains length limits."
+				}
+			}
+		],
+		"outputs": {
+			"Location": "[location()]"
+		}
+	}
 }


### PR DESCRIPTION
fixes #731

### Current Code

- The test only checks to see if the length constraint has been provided at the start and end of the regex string but it is possible for the length constraint to be present anywhere in the string. 
- Additionally the current test only returns success if length constraint of the pattern `{m,n}` or `{m,}` is provided while there is a third valid option `{m}` which will return failure.

### Updated Code

- Since we only need to check if length constraint has been provided somewhere in the input regex string there is no need to check the start and end of the string separately instead a search of the entire string should be sufficient.
- Added support for the `{m}` variant of length constraint which was not currently supported.
- Updated the Units Tests with additional test conditions to check a more broader range of possible inputs.

Additional test cases that where validated can be found here: https://regex101.com/r/fde0fy/3