### PR TITLE
Create Outputs-Cannot-Contain-ListKeys-Variables.json

### DIFF
--- a/unit-tests/Outputs-Must-Not-Contain-Secrets/Fail/Outputs-Cannot-Contain-ListKeys-Variables.json
+++ b/unit-tests/Outputs-Must-Not-Contain-Secrets/Fail/Outputs-Cannot-Contain-ListKeys-Variables.json
@@ -2,12 +2,13 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "variables": {
-      "varStorageName": "[concat('connection string blah=', listKeys ( 'storageAccountName','2017-10-01').keys[0].value)]"
+      "keys": "[account.listKeys()]",
+      "cassandraConnectionString": "[concat('Password=', keys.primaryMasterKey)]"
     },
     "outputs": {
-        "containsListKeysConcat": {
+        "cassandraConnectionString": {
             "type": "string",
-            "value": "[variables('varStorageName')]"
+            "value": "[variables('cassandraConnectionString')]"
         }
     }
 }

--- a/unit-tests/Outputs-Must-Not-Contain-Secrets/Fail/Outputs-Cannot-Contain-ListKeys-Variables.json
+++ b/unit-tests/Outputs-Must-Not-Contain-Secrets/Fail/Outputs-Cannot-Contain-ListKeys-Variables.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "variables": {
+      "varStorageName": "[concat('connection string blah=', listKeys ( 'storageAccountName','2017-10-01').keys[0].value)]"
+    },
+    "outputs": {
+        "containsListKeysConcat": {
+            "type": "string",
+            "value": "[variables('varStorageName')]"
+        }
+    }
+}


### PR DESCRIPTION
Add example of case that is expected to fail.

@bmoore-msft, per the discussion over [here](https://github.com/Azure/bicep/discussions/9293) seems that in Bicep, when the output of listKeys is assigned to a variable, and then an output, no alert is triggered. But, I thought I had seen ARM-TTK properly catch this in the past.... Proposing this test case to confirm or deny my memory.

If this test case passes, we could merge this PR in as confirmation. But if it fails, I expect the fix would be done on the bicep side.