### PR TITLE
EditableGrid does not need tooltips

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/Tooltips-Should-Be-Present.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Tooltips-Should-Be-Present.test.ps1
@@ -21,7 +21,8 @@ $shouldHaveTooltips = $CreateUIDefinitionObject |
 $noToolTipControls = "Microsoft.Common.InfoBox", 
                      "Microsoft.Common.Section", 
                      "Microsoft.Common.TextBlock", 
-                     "Microsoft.Solutions.ArmApiControl"
+                     "Microsoft.Solutions.ArmApiControl",
+                     "Microsoft.Common.EditableGrid"
 
 foreach ($shouldHave in $shouldHaveTooltips) {
     # then loop through each control

--- a/unit-tests/Tooltips-Should-Be-Present/Pass/EditableGridTooltipNotRequired/azuredeploy.json
+++ b/unit-tests/Tooltips-Should-Be-Present/Pass/EditableGridTooltipNotRequired/azuredeploy.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+  ]
+}

--- a/unit-tests/Tooltips-Should-Be-Present/Pass/EditableGridTooltipNotRequired/createUiDefinition.json
+++ b/unit-tests/Tooltips-Should-Be-Present/Pass/EditableGridTooltipNotRequired/createUiDefinition.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/0.1.2-preview/CreateUIDefinition.MultiVm.json#",
+    "handler": "Microsoft.Azure.CreateUIDef",
+    "version": "0.1.2-preview",
+    "parameters": {
+        "basics": [
+            {
+                "name": "EditableGrid",
+                "type": "Microsoft.Common.EditableGrid",
+                "label": "Editable don't need tooltips"
+            }
+        ],
+        "outputs": {
+            "Location": "[location()]"
+        }
+    }
+}


### PR DESCRIPTION
Related to issue https://github.com/Azure/arm-ttk/issues/733
 EditableGrid does not require tooltips in the public schema and this should be followed for toolkit also.
Additional test for the same has been added.