### PR TITLE
Addressing fixes for GitHub issues 738, 753 and 745

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
@@ -55,7 +55,7 @@ foreach ($inner in $originalInnerTemplates) {
                 {
                     $innerTemplateParamValue = $innerTemplateParamValue.value
                 }
-                if(($innerTemplateParamValue -isnot [array]) -and ($innerTemplateParamValue -notmatch $regexParam))
+                if(($innerTemplateParamValue -is [string]) -and ($innerTemplateParamValue -notmatch $regexParam))
                 {
                     # If this is the case, write an error
                 Write-Error -ErrorId Inconsistent.Parameter -Message "Type Mismatch: Parameter '$parameterName' in nested template '$($inner.ParentObject[0].name)' is defined as $innerTemplateParameterType, but the parent template defines it as $($parent.parameters.$mappedParameterName.type))." -TargetObject ([PSCustomObject]@{

--- a/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
@@ -50,19 +50,19 @@ foreach ($inner in $originalInnerTemplates) {
                 $parent.parameters.$mappedParameterName.type -ne $innerTemplateParameterType # with a different type.    
             ) {
                 $innerTemplateParamValue = $innerTemplateParam.Value
-                $regexParam = "parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.|\,)(.*)\]" # https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
+                $regexParam = ".*parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.|\,)(.*)\]" # https://regex101.com/r/V0dzVv/1 and https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
                 if($null -ne $innerTemplateParamValue.value)
                 {
                     $innerTemplateParamValue = $innerTemplateParamValue.value
                 }
                 if(($innerTemplateParamValue -is [string]) -and ($innerTemplateParamValue -notmatch $regexParam))
                 {
-                    # If this is the case, write an error
+                # If this is the case, write an error
                 Write-Error -ErrorId Inconsistent.Parameter -Message "Type Mismatch: Parameter '$parameterName' in nested template '$($inner.ParentObject[0].name)' is defined as $innerTemplateParameterType, but the parent template defines it as $($parent.parameters.$mappedParameterName.type))." -TargetObject ([PSCustomObject]@{
-                    JSONPath = $inner.JSONPath + ".parameters.$parameterName"})
+                    JSONPath = $inner.JSONPath + ".parameters.$parameterName"
+                })
                 break # and then stop processing, because we only wish to compare this against the immediate parent template.
                 }
-                
             }
         }
     }

--- a/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
@@ -50,7 +50,7 @@ foreach ($inner in $originalInnerTemplates) {
                 $parent.parameters.$mappedParameterName.type -ne $innerTemplateParameterType # with a different type.    
             ) {
                 $innerTemplateParamValue = $innerTemplateParam.Value
-                $regexParam = "[.*parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.|\,)(.*)\]" # https://regex101.com/r/V0dzVv/1 and https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
+                $regexParam = "\[.*parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.|\,)(.*)\]" # https://regex101.com/r/V0dzVv/1 and https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
                 if($null -ne $innerTemplateParamValue.value)
                 {
                     $innerTemplateParamValue = $innerTemplateParamValue.value

--- a/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
@@ -50,7 +50,7 @@ foreach ($inner in $originalInnerTemplates) {
                 $parent.parameters.$mappedParameterName.type -ne $innerTemplateParameterType # with a different type.    
             ) {
                 $innerTemplateParamValue = $innerTemplateParam.Value
-                $regexParam = ".*parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.|\,)(.*)\]" # https://regex101.com/r/V0dzVv/1 and https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
+                $regexParam = "[.*parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.|\,)(.*)\]" # https://regex101.com/r/V0dzVv/1 and https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
                 if($null -ne $innerTemplateParamValue.value)
                 {
                     $innerTemplateParamValue = $innerTemplateParamValue.value

--- a/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Parameter-Types-Should-Be-Consistent.test.ps1
@@ -47,14 +47,22 @@ foreach ($inner in $originalInnerTemplates) {
 
         foreach ($parent in $inner.ParentObject) { # Walk up the list of parent objects until
             if ($parent.parameters.$mappedParameterName.type -and  # We find this parameter defined
-                $parent.parameters.$mappedParameterName.type -ne $innerTemplateParameterType -and # with a different type.
-                $innerTemplateParam.Value.value -notmatch "\[parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.)(.*)\]" # https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
+                $parent.parameters.$mappedParameterName.type -ne $innerTemplateParameterType # with a different type.    
             ) {
-                # If this is the case, write an error
+                $innerTemplateParamValue = $innerTemplateParam.Value
+                $regexParam = "parameters(?<mappedParameterName>\(.*\))(\[.*?\]|\.|\,)(.*)\]" # https://regex101.com/r/ao6tsK/1 https://github.com/Azure/arm-ttk/issues/635
+                if($null -ne $innerTemplateParamValue.value)
+                {
+                    $innerTemplateParamValue = $innerTemplateParamValue.value
+                }
+                if(($innerTemplateParamValue -isnot [array]) -and ($innerTemplateParamValue -notmatch $regexParam))
+                {
+                    # If this is the case, write an error
                 Write-Error -ErrorId Inconsistent.Parameter -Message "Type Mismatch: Parameter '$parameterName' in nested template '$($inner.ParentObject[0].name)' is defined as $innerTemplateParameterType, but the parent template defines it as $($parent.parameters.$mappedParameterName.type))." -TargetObject ([PSCustomObject]@{
-                    JSONPath = $inner.JSONPath + ".parameters.$parameterName"
-                })
+                    JSONPath = $inner.JSONPath + ".parameters.$parameterName"})
                 break # and then stop processing, because we only wish to compare this against the immediate parent template.
+                }
+                
             }
         }
     }

--- a/unit-tests/Parameter-Types-Should-Be-Consistent/Pass/bicepTemplate.json
+++ b/unit-tests/Parameter-Types-Should-Be-Consistent/Pass/bicepTemplate.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.22.6.54827",
+      "templateHash": "2557909781805504768"
+    }
+  },
+  "parameters": {
+    "choice": {
+      "type": "bool"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "module1",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "intext": "[if(parameters('choice'), createObject('value', 'foo'), createObject('value', 'bar'))]"
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.22.6.54827",
+              "templateHash": "10164220933236466129"
+            }
+          },
+          "parameters": {
+            "intext": {
+              "type": "string"
+            }
+          },
+          "resources": [],
+          "outputs": {
+            "outtext": {
+              "type": "string",
+              "value": "[parameters('intext')]"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/unit-tests/Parameter-Types-Should-Be-Consistent/Pass/innerParamArrayBicepTemplate.json
+++ b/unit-tests/Parameter-Types-Should-Be-Consistent/Pass/innerParamArrayBicepTemplate.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.13.1.58284",
+      "templateHash": "6364080903705651062"
+    }
+  },
+  "parameters": {
+    "textParam2": {
+      "type": "string",
+      "defaultValue": "container2"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2020-10-01",
+      "name": "mod1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "arrayParam": {
+            "value": [
+              "first",
+              "[parameters('textParam2')]",
+              "last"
+            ]
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.13.1.58284",
+              "templateHash": "279482116342234053"
+            }
+          },
+          "parameters": {
+            "arrayParam": {
+              "type": "array",
+              "defaultValue": []
+            }
+          },
+          "resources": [],
+          "outputs": {
+            "outArray": {
+              "type": "array",
+              "value": "[parameters('arrayParam')]"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/unit-tests/Parameter-Types-Should-Be-Consistent/Pass/twoModuleBicepTemplate.json
+++ b/unit-tests/Parameter-Types-Should-Be-Consistent/Pass/twoModuleBicepTemplate.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.22.6.54827",
+      "templateHash": "12026618333363551042"
+    }
+  },
+  "parameters": {
+    "input": {
+      "type": "object"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[parameters('input').module_one]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "intext": {
+            "value": "hello"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.22.6.54827",
+              "templateHash": "15717468013965412695"
+            }
+          },
+          "parameters": {
+            "intext": {
+              "type": "string"
+            }
+          },
+          "resources": [],
+          "outputs": {
+            "outtext": {
+              "type": "string",
+              "value": "[parameters('intext')]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "moduleTwo",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "intext": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', parameters('input').module_one), '2022-09-01').outputs.outtext.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.22.6.54827",
+              "templateHash": "15717468013965412695"
+            }
+          },
+          "parameters": {
+            "intext": {
+              "type": "string"
+            }
+          },
+          "resources": [],
+          "outputs": {
+            "outtext": {
+              "type": "string",
+              "value": "[parameters('intext')]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', parameters('input').module_one)]"
+      ]
+    }
+  ]
+}

--- a/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
+++ b/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
@@ -4,7 +4,7 @@
     "resources": [
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "apiVersion": "2022-09-01",
+            "apiVersion": "2023-04-01",
             "name": "[format('{0}/default/{1}', variables('storageAccountName'), variables('blobContainerName'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"

--- a/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
+++ b/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
@@ -4,7 +4,7 @@
     "resources": [
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "apiVersion": "2021-09-01",
+            "apiVersion": "2022-09-01",
             "name": "[format('{0}/default/{1}', variables('storageAccountName'), variables('blobContainerName'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"


### PR DESCRIPTION
Before this fix if an inner template parameter referenced a parent template parameter, if the value of the inner template parameter was not in the form [parameters('parenttemplateparam').....] or  [parameters('parenttemplateparam')] then an error would be thrown. This PR fixes the regex where the error will not be thrown to include values like *parameter('parenttemplateparam')... or *parameter('parenttemplateparam'), or *parameter('parenttemplateparam')]
Also if the VALUE of an innertemplateparam is an object, then the correct value was not retrieved previously. This is also fixed.

Addressing issues:
https://github.com/Azure/arm-ttk/issues/745
(Removed the condition to have '[' before parameters and a comma can be accepted besides '.' and ']')
Test file unit-tests/Parameter-Types-Should-Be-Consistent/Pass/bicepTemplate.json is related

https://github.com/Azure/arm-ttk/issues/753
Test file unit-tests/Parameter-Types-Should-Be-Consistent/Pass/innerParamArrayBicepTemplate.json is a test for this issue
The code change where the inner template parameter value.value is retrieved and if the type is not a string then the error is not thrown.

https://github.com/Azure/arm-ttk/issues/738
Test file unit-tests/Parameter-Types-Should-Be-Consistent/Pass/twoModuleBicepTemplate.json is a test for this issue
The regex fix to remove the requirement of the regex to always have its value to begin with '[parameters' is lifted.