### PR TITLE
Changing convertfrom-json utility usage based on powershell version (powershell 6+ has utility for json comments)

### DIFF
--- a/arm-ttk/ConvertFrom-JSON.ps1
+++ b/arm-ttk/ConvertFrom-JSON.ps1
@@ -45,7 +45,7 @@ process
 
         # First, strip block comments
         $inObj = $_
-        $in = if ($InputObject.Contains('*/')) { 
+        $in = if ($InputObject.Contains('*/') -and $InputObject.Contains('/*')) { 
             $JSONBlockComments.Replace($inObj,'')
         } else {
             $InputObject

--- a/arm-ttk/arm-ttk.psm1
+++ b/arm-ttk/arm-ttk.psm1
@@ -1,5 +1,6 @@
 ﻿#region JSON Functions
-if ($PSVersionTable.PSEdition -ne 'Core') {
+#powershell 6+ provides support for json with comments
+if ($PSVersionTable.PSVersion.Major -lt 5) {
     . $psScriptRoot\ConvertFrom-Json.ps1 # Overwriting ConvertFrom-JSON to allow for comments within JSON (not on core)
 }
 

--- a/arm-ttk/arm-ttk.psm1
+++ b/arm-ttk/arm-ttk.psm1
@@ -1,6 +1,6 @@
 ﻿#region JSON Functions
 #powershell 6+ provides support for json with comments
-if ($PSVersionTable.PSVersion.Major -lt 5) {
+if ($PSVersionTable.PSVersion.Major -lt 6) {
     . $psScriptRoot\ConvertFrom-Json.ps1 # Overwriting ConvertFrom-JSON to allow for comments within JSON (not on core)
 }
 

--- a/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
+++ b/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
@@ -4,7 +4,7 @@
     "resources": [
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "apiVersion": "2022-09-01",
+            "apiVersion": "2023-04-01",
             "name": "[format('{0}/default/{1}', variables('storageAccountName'), variables('blobContainerName'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"

--- a/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
+++ b/unit-tests/apiversions-should-be-recent/Pass/Nested-API-Version.json
@@ -4,7 +4,7 @@
     "resources": [
         {
             "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
-            "apiVersion": "2021-09-01",
+            "apiVersion": "2022-09-01",
             "name": "[format('{0}/default/{1}', variables('storageAccountName'), variables('blobContainerName'))]",
             "dependsOn": [
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"


### PR DESCRIPTION
Fixing issue https://github.com/Azure/arm-ttk/issues/737
Running the template provided in the above issue, if using the custom ConvertFrom-JSON utility, it fails.
The code change here changes the utility used to be the default powershell version if the powershell major version is equal to or above 6.
There is a small fix in the convertfrom-json utility where for recognizing comments both the starting and ending characters are searched.
