### PR TITLE
Added property requiredDataConnectors in Template-Should-Not-Contain-Blanks Test to skip if []

### DIFF
--- a/arm-ttk/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
+++ b/arm-ttk/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
@@ -32,7 +32,8 @@ param(
                             'clientId', # Microsoft.ContainerService/managedClusters.properties.servicePrincipalProfile
                             'allowedCallerIpAddresses', # Microsoft.Logic/workflows Access Control
                             'workerPools', # Microsoft.Web/hostingEnvironments
-                            'AzureMonitor' # Microsoft.Insights/VMDiagnosticsSettings
+                            'AzureMonitor', # Microsoft.Insights/VMDiagnosticsSettings
+                            'requiredDataConnectors' #Microsoft.SecurityInsights/AlertRuleTemplates
     ),
 
     # Some properties can be empty within a given resource.

--- a/unit-tests/Template-Should-Not-Contain-Blanks/Pass/requiredDataConnectors-empty-array-should-pass.json
+++ b/unit-tests/Template-Should-Not-Contain-Blanks/Pass/requiredDataConnectors-empty-array-should-pass.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "resources": [
+    {
+      "type": "Microsoft.OperationalInsights/workspaces/providers/contentTemplates",
+      "name": "TestAnalyticRule",
+      "properties": {
+        "mainTemplate": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.2",
+          "parameters": {},
+          "variables": {},
+          "resources": [
+            {
+              "type": "Microsoft.SecurityInsights/AlertRuleTemplates",
+              "name": "TestAnalyticRuleName",
+              "apiVersion": "2022-04-01-preview",
+              "kind": "Scheduled",
+              "properties": {
+                "displayName": "Test Rule",
+                "enabled": false,
+                "query": "Test Query",
+                "requiredDataConnectors": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}


### PR DESCRIPTION
Ignore "requiredDataConnectors" property if [].

After running tests locally we see below for the added test case on "requiredDataConnectors" property :
![image](https://github.com/Azure/arm-ttk/assets/107389644/400baef3-1a6b-498b-8370-49334c02873d)

