### PR TITLE
Added Microsoft.Solutions.GraphApiControl to the no-ToolTip controls

### DIFF
--- a/arm-ttk/testcases/CreateUIDefinition/Tooltips-Should-Be-Present.test.ps1
+++ b/arm-ttk/testcases/CreateUIDefinition/Tooltips-Should-Be-Present.test.ps1
@@ -22,6 +22,7 @@ $noToolTipControls = "Microsoft.Common.InfoBox",
                      "Microsoft.Common.Section", 
                      "Microsoft.Common.TextBlock", 
                      "Microsoft.Solutions.ArmApiControl",
+                     "Microsoft.Solutions.GraphApiControl",
                      "Microsoft.Common.EditableGrid"
 
 foreach ($shouldHave in $shouldHaveTooltips) {


### PR DESCRIPTION
Updated Tooltips-Should-Be-Present.test.ps1 to add Microsoft.Solutions.GraphApiControl to the list of controls that do not need to be checked for a ToolTip since Microsoft.Solutions.GraphApiControl has no UI.