### PR TITLE
Implemented functionality to convert the test result format into JSON

### DIFF
--- a/arm-ttk/Format-Json.ps1
+++ b/arm-ttk/Format-Json.ps1
@@ -1,0 +1,55 @@
+Function Format-Json {
+    <#
+    .SYNOPSIS
+        Takes results from ARMTTK and exports them as a JSON blob.
+    .DESCRIPTION
+        Takes results from ARMTTK and exports them as JSON. The test cases include the filename, name of the test,
+        whether the test was successful, and help text for how to resolve the error if the test failed.
+    #>
+    [CmdletBinding()]
+    Param (
+        # Object containing a single test result or an array of test results
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [psobject]$TestResult
+    )
+
+    Begin {
+        # Initialize the array to collect processed test cases
+        $TestCases = @()
+    }
+
+    Process {
+        # Process each TestResult item one by one as they come from the pipeline
+        $TestCase = @{
+            filepath = $TestResult.file.fullpath
+            name = $TestResult.name
+            success = $TestResult.Passed
+        }
+
+        if ($TestResult.Passed) {
+            $TestCase.optional = $false
+        }
+        elseif ($null -ne $($TestResult.Warnings)) {
+            $TestCase.optional = $true
+            $TestCase.message = "$($TestResult.Warnings.Message.Replace('"', '\"')) in template file $($TestResult.file.name)"
+        }
+        elseif ($null -ne $($TestResult.Errors)) {
+            $TestCase.optional = $false
+            $TestCase.message = "$($TestResult.Errors.Exception.Message.Replace('"', '\"')) in template file $($TestResult.file.name)"
+        }
+        else {
+            $TestCase.optional = $true
+            $TestCase.message = "Unknown error in template file " + $TestResult.file.name
+        }
+
+        $TestCases += $TestCase
+    }
+
+    End {
+        # Convert the array of hashtables to JSON
+        $JSON = $TestCases | ConvertTo-Json -Depth 5
+
+        # Print the JSON string to the console
+        Write-Output $JSON
+    }
+}

--- a/arm-ttk/Format-Json.ps1
+++ b/arm-ttk/Format-Json.ps1
@@ -47,7 +47,7 @@ Function Format-Json {
 
     End {
         # Convert the array of hashtables to JSON
-        $JSON = $TestCases | ConvertTo-Json -Depth 5
+        $JSON = $TestCases | ConvertTo-Json
 
         # Print the JSON string to the console
         Write-Output $JSON

--- a/arm-ttk/README.md
+++ b/arm-ttk/README.md
@@ -26,7 +26,7 @@ You can also skip tests any tests:
     Test-AzTemplate -TemplatePath $thePathToYourTemplate -Skip apiVersions-Should-Be-Recent 
     # This will exclude the tests indicated by the -Skip parameter from the test run and results    
 
-You can also change the output format to JSON:
+You can also change the output format to get detailed test result descriptions in JSON:
 
     Test-AzTemplate -TemplatePath $thePathToYourTemplate | Format-Json
     # This will output the test results from Test-AzTemplate to the console in JSON format

--- a/arm-ttk/README.md
+++ b/arm-ttk/README.md
@@ -24,7 +24,14 @@ This will run the full suite of applicable tests on your template.  To run a spe
 You can also skip tests any tests:
 
     Test-AzTemplate -TemplatePath $thePathToYourTemplate -Skip apiVersions-Should-Be-Recent 
-    # This will exclude the tests indicated by the -Skip parameter from the test run and results     
+    # This will exclude the tests indicated by the -Skip parameter from the test run and results    
+
+You can also change the output format to JSON:
+
+    Test-AzTemplate -TemplatePath $thePathToYourTemplate | Format-Json
+    # This will output the test results from Test-AzTemplate to the console in JSON format
+    Test-AzMarketplacePackage -TemplatePath $thePathToYourTemplate | Format-Json
+    # This will output the test results from AzMarketplacePackage to the console in JSON format
 
 ## Running Tests on Linux
 


### PR DESCRIPTION
This PR enables the functionality of outputting the test results generated by Test-AzTemplate and Test-AzMarketplacePackage in JSON format.

The MCISV team has requested this feature.

You can try it out with the following command(s):
`Test-AzTemplate -TemplatePath <path> | Format-JSON`
or
`Test-AzMarketplacePackage -TemplatePath <path> | Format-JSON`
