### PR TITLE
Bug: Missing dot-import for Format-Json

### DIFF
--- a/arm-ttk/arm-ttk.psm1
+++ b/arm-ttk/arm-ttk.psm1
@@ -16,6 +16,7 @@ if ($PSVersionTable.PSVersion.Major -lt 6) {
 . $PSScriptRoot\Test-AzMarketplacePackage.ps1
 
 . $PSScriptRoot\Format-AzTemplate.ps1
+. $PSScriptRoot\Format-Json.ps1
 #endregion Template Functions
 
 #region Cache Functions


### PR DESCRIPTION
In order for Format-Json to be automatically included when importing the arm-ttk module, Format-Json needs to be dot-imported in the arm-ttk.psm1.